### PR TITLE
fix: ノード内フォーム要素にnodragクラスを追加してドラッグ時のノード移動を防止

### DIFF
--- a/frontend/src/components/Node/AddRoleToRoleMembersNode.tsx
+++ b/frontend/src/components/Node/AddRoleToRoleMembersNode.tsx
@@ -129,7 +129,7 @@ export const AddRoleToRoleMembersNode = ({
           </label>
           <input
             type="text"
-            className="input input-bordered w-full"
+            className="nodrag input input-bordered w-full"
             value={data.memberRoleName}
             onChange={(evt) => handleMemberRoleNameChange(evt.target.value)}
             placeholder="例: プレイヤー"
@@ -142,7 +142,7 @@ export const AddRoleToRoleMembersNode = ({
           </label>
           <input
             type="text"
-            className="input input-bordered w-full"
+            className="nodrag input input-bordered w-full"
             value={data.addRoleName}
             onChange={(evt) => handleAddRoleNameChange(evt.target.value)}
             placeholder="例: 参加者"
@@ -154,7 +154,7 @@ export const AddRoleToRoleMembersNode = ({
         <BaseNodeFooter>
           <button
             type="button"
-            className="btn btn-primary"
+            className="nodrag btn btn-primary"
             onClick={handleExecute}
             disabled={isLoading || !!data.executedAt}
           >

--- a/frontend/src/components/Node/ChangeChannelPermissionNode.tsx
+++ b/frontend/src/components/Node/ChangeChannelPermissionNode.tsx
@@ -189,7 +189,7 @@ export const ChangeChannelPermissionNode = ({
           {/* Channel name input */}
           <input
             type="text"
-            className="input input-bordered input-sm w-full"
+            className="nodrag input input-bordered input-sm w-full"
             value={data.channelName}
             onChange={(evt) => handleChannelNameChange(evt.target.value)}
             placeholder="チャンネル名"
@@ -223,7 +223,7 @@ export const ChangeChannelPermissionNode = ({
               <div key={`${id}-role-${roleIndex}`} className="flex gap-2 items-center">
                 <input
                   type="text"
-                  className="input input-bordered input-xs flex-1"
+                  className="nodrag input input-bordered input-xs flex-1"
                   value={perm.roleName}
                   onChange={(e) =>
                     handleRolePermissionChange(roleIndex, "roleName", e.target.value)
@@ -231,7 +231,7 @@ export const ChangeChannelPermissionNode = ({
                   placeholder="ロール名"
                   disabled={isLoading}
                 />
-                <label className="flex items-center gap-1 cursor-pointer">
+                <label className="nodrag flex items-center gap-1 cursor-pointer">
                   <span className="text-xs">読み取り</span>
                   <input
                     type="checkbox"
@@ -246,7 +246,7 @@ export const ChangeChannelPermissionNode = ({
                 </label>
                 <button
                   type="button"
-                  className="btn btn-ghost btn-xs"
+                  className="nodrag btn btn-ghost btn-xs"
                   onClick={() => handleRemoveRolePermission(roleIndex)}
                   disabled={isLoading}
                 >
@@ -256,7 +256,7 @@ export const ChangeChannelPermissionNode = ({
             ))}
             <button
               type="button"
-              className="btn btn-ghost btn-xs"
+              className="nodrag btn btn-ghost btn-xs"
               onClick={handleAddRolePermission}
               disabled={isLoading}
             >
@@ -279,7 +279,7 @@ export const ChangeChannelPermissionNode = ({
         <BaseNodeFooter>
           <button
             type="button"
-            className="btn btn-primary"
+            className="nodrag btn btn-primary"
             onClick={handleChangePermissions}
             disabled={isLoading || !!data.executedAt}
           >

--- a/frontend/src/components/Node/CreateCategoryNode.tsx
+++ b/frontend/src/components/Node/CreateCategoryNode.tsx
@@ -90,7 +90,7 @@ export const CreateCategoryNode = ({
       <BaseNodeContent>
         <input
           type="text"
-          className="input input-bordered w-full"
+          className="nodrag input input-bordered w-full"
           value={data.categoryName}
           onChange={(evt) => handleCategoryNameChange(evt.target.value)}
           placeholder="カテゴリ名を入力"
@@ -101,7 +101,7 @@ export const CreateCategoryNode = ({
         <BaseNodeFooter>
           <button
             type="button"
-            className="btn btn-primary"
+            className="nodrag btn btn-primary"
             onClick={handleCreateCategory}
             disabled={isLoading || !!data.executedAt}
           >

--- a/frontend/src/components/Node/CreateChannelNode.tsx
+++ b/frontend/src/components/Node/CreateChannelNode.tsx
@@ -236,13 +236,13 @@ export const CreateChannelNode = ({
               <div className="flex gap-2 items-center mb-2">
                 <input
                   type="text"
-                  className="input input-bordered input-sm flex-1"
+                  className="nodrag input input-bordered input-sm flex-1"
                   value={channel.name}
                   onChange={(evt) => handleChannelChange(channelIndex, "name", evt.target.value)}
                   placeholder="チャンネル名"
                   disabled={isLoading}
                 />
-                <label className="flex items-center gap-1 cursor-pointer">
+                <label className="nodrag flex items-center gap-1 cursor-pointer">
                   <span className="text-xs">テキスト</span>
                   <input
                     type="checkbox"
@@ -257,7 +257,7 @@ export const CreateChannelNode = ({
                 </label>
                 <button
                   type="button"
-                  className="btn btn-ghost btn-sm"
+                  className="nodrag btn btn-ghost btn-sm"
                   onClick={() => handleRemoveChannel(channelIndex)}
                   disabled={isLoading}
                 >
@@ -275,7 +275,7 @@ export const CreateChannelNode = ({
                   >
                     <input
                       type="text"
-                      className="input input-bordered input-xs flex-1"
+                      className="nodrag input input-bordered input-xs flex-1"
                       value={perm.roleName}
                       onChange={(e) =>
                         handleRolePermissionChange(
@@ -288,7 +288,7 @@ export const CreateChannelNode = ({
                       placeholder="ロール名"
                       disabled={isLoading}
                     />
-                    <label className="flex items-center gap-1 cursor-pointer">
+                    <label className="nodrag flex items-center gap-1 cursor-pointer">
                       <span className="text-xs">読み取り</span>
                       <input
                         type="checkbox"
@@ -308,7 +308,7 @@ export const CreateChannelNode = ({
                     </label>
                     <button
                       type="button"
-                      className="btn btn-ghost btn-xs"
+                      className="nodrag btn btn-ghost btn-xs"
                       onClick={() => handleRemoveRolePermission(channelIndex, roleIndex)}
                       disabled={isLoading}
                     >
@@ -318,7 +318,7 @@ export const CreateChannelNode = ({
                 ))}
                 <button
                   type="button"
-                  className="btn btn-ghost btn-xs"
+                  className="nodrag btn btn-ghost btn-xs"
                   onClick={() => handleAddRolePermission(channelIndex)}
                   disabled={isLoading}
                 >
@@ -338,7 +338,7 @@ export const CreateChannelNode = ({
 
         <button
           type="button"
-          className="btn btn-ghost btn-sm mt-2"
+          className="nodrag btn btn-ghost btn-sm mt-2"
           onClick={handleAddChannel}
           disabled={isLoading}
         >
@@ -362,7 +362,7 @@ export const CreateChannelNode = ({
         <BaseNodeFooter>
           <button
             type="button"
-            className="btn btn-primary"
+            className="nodrag btn btn-primary"
             onClick={handleCreateChannels}
             disabled={isLoading || !!data.executedAt}
           >

--- a/frontend/src/components/Node/CreateRoleNode.tsx
+++ b/frontend/src/components/Node/CreateRoleNode.tsx
@@ -114,7 +114,7 @@ export const CreateRoleNode = ({
           <div key={`${id}-role-${index}`} className="flex gap-2 items-center mb-2">
             <input
               type="text"
-              className="input input-bordered w-full"
+              className="nodrag input input-bordered w-full"
               value={role}
               onChange={(evt) => handleRoleChange(index, evt.target.value)}
               placeholder="ロール名を入力"
@@ -123,7 +123,7 @@ export const CreateRoleNode = ({
             {!isExecuteMode && (
               <button
                 type="button"
-                className="btn btn-ghost btn-sm"
+                className="nodrag btn btn-ghost btn-sm"
                 onClick={() => handleRemoveRole(index)}
               >
                 削除
@@ -132,7 +132,11 @@ export const CreateRoleNode = ({
           </div>
         ))}
         {!isExecuteMode && (
-          <button type="button" className="btn btn-ghost btn-sm mt-2" onClick={handleAddRole}>
+          <button
+            type="button"
+            className="nodrag btn btn-ghost btn-sm mt-2"
+            onClick={handleAddRole}
+          >
             ロールを追加
           </button>
         )}
@@ -153,7 +157,7 @@ export const CreateRoleNode = ({
         <BaseNodeFooter>
           <button
             type="button"
-            className="btn btn-primary"
+            className="nodrag btn btn-primary"
             onClick={handleCreateRoles}
             disabled={isLoading || !!data.executedAt}
           >

--- a/frontend/src/components/Node/DeleteChannelNode.tsx
+++ b/frontend/src/components/Node/DeleteChannelNode.tsx
@@ -140,7 +140,7 @@ export const DeleteChannelNode = ({
           <div key={`${id}-channel-${index}`} className="flex gap-2 items-center mb-2">
             <input
               type="text"
-              className="input input-bordered w-full"
+              className="nodrag input input-bordered w-full"
               value={name}
               onChange={(evt) => handleChannelNameChange(index, evt.target.value)}
               placeholder="チャンネル名を入力"
@@ -149,7 +149,7 @@ export const DeleteChannelNode = ({
             {!isExecuteMode && (
               <button
                 type="button"
-                className="btn btn-ghost btn-sm"
+                className="nodrag btn btn-ghost btn-sm"
                 onClick={() => handleRemoveChannelName(index)}
               >
                 削除
@@ -160,7 +160,7 @@ export const DeleteChannelNode = ({
         {!isExecuteMode && (
           <button
             type="button"
-            className="btn btn-ghost btn-sm mt-2"
+            className="nodrag btn btn-ghost btn-sm mt-2"
             onClick={handleAddChannelName}
           >
             チャンネルを追加
@@ -183,7 +183,7 @@ export const DeleteChannelNode = ({
         <BaseNodeFooter>
           <button
             type="button"
-            className="btn btn-error"
+            className="nodrag btn btn-error"
             onClick={handleDeleteChannels}
             disabled={isLoading || !!data.executedAt}
           >

--- a/frontend/src/components/Node/DeleteRoleNode.tsx
+++ b/frontend/src/components/Node/DeleteRoleNode.tsx
@@ -155,7 +155,7 @@ export const DeleteRoleNode = ({
       </BaseNodeHeader>
       <BaseNodeContent>
         <div className="form-control mb-2">
-          <label className="label cursor-pointer justify-start gap-2">
+          <label className="nodrag label cursor-pointer justify-start gap-2">
             <input
               type="checkbox"
               className="checkbox"
@@ -173,7 +173,7 @@ export const DeleteRoleNode = ({
               <div key={`${id}-role-${index}`} className="flex gap-2 items-center mb-2">
                 <input
                   type="text"
-                  className="input input-bordered w-full"
+                  className="nodrag input input-bordered w-full"
                   value={name}
                   onChange={(evt) => handleRoleNameChange(index, evt.target.value)}
                   placeholder="ロール名を入力"
@@ -182,7 +182,7 @@ export const DeleteRoleNode = ({
                 {!isExecuteMode && (
                   <button
                     type="button"
-                    className="btn btn-ghost btn-sm"
+                    className="nodrag btn btn-ghost btn-sm"
                     onClick={() => handleRemoveRoleName(index)}
                   >
                     削除
@@ -193,7 +193,7 @@ export const DeleteRoleNode = ({
             {!isExecuteMode && (
               <button
                 type="button"
-                className="btn btn-ghost btn-sm mt-2"
+                className="nodrag btn btn-ghost btn-sm mt-2"
                 onClick={handleAddRoleName}
               >
                 ロールを追加
@@ -219,7 +219,7 @@ export const DeleteRoleNode = ({
         <BaseNodeFooter>
           <button
             type="button"
-            className="btn btn-error"
+            className="nodrag btn btn-error"
             onClick={handleDeleteRoles}
             disabled={isLoading || !!data.executedAt}
           >

--- a/frontend/src/components/Node/SendMessageNode.tsx
+++ b/frontend/src/components/Node/SendMessageNode.tsx
@@ -265,7 +265,7 @@ export const SendMessageNode = ({
             <label className="text-xs font-semibold mb-1 block">送信先チャンネル</label>
             <input
               type="text"
-              className="input input-bordered input-sm w-full"
+              className="nodrag input input-bordered input-sm w-full"
               value={data.channelName}
               onChange={(e) => handleChannelNameChange(e.target.value)}
               placeholder="チャンネル名"
@@ -277,7 +277,7 @@ export const SendMessageNode = ({
           <div>
             <label className="text-xs font-semibold mb-1 block">メッセージ</label>
             <textarea
-              className="textarea textarea-bordered w-full h-24"
+              className="nodrag textarea textarea-bordered w-full h-24"
               value={data.content}
               onChange={(e) => handleContentChange(e.target.value)}
               placeholder="メッセージを入力"
@@ -313,7 +313,7 @@ export const SendMessageNode = ({
                     )}
                     <button
                       type="button"
-                      className="btn btn-ghost btn-xs"
+                      className="nodrag btn btn-ghost btn-xs"
                       onClick={() => handleFileRemove(index)}
                       disabled={isLoading}
                     >
@@ -344,7 +344,7 @@ export const SendMessageNode = ({
                 />
                 <button
                   type="button"
-                  className="btn btn-ghost btn-sm"
+                  className="nodrag btn btn-ghost btn-sm"
                   onClick={() => fileInputRef.current?.click()}
                   disabled={isLoading}
                 >
@@ -367,7 +367,7 @@ export const SendMessageNode = ({
         <BaseNodeFooter>
           <button
             type="button"
-            className="btn btn-primary"
+            className="nodrag btn btn-primary"
             onClick={handleSendMessage}
             disabled={isLoading || !!data.executedAt}
           >


### PR DESCRIPTION
## Summary
- ノード内のフォーム要素（input, textarea, button, toggle）にReact Flowの`nodrag`クラスを追加
- フォーム要素をドラッグした際にノード全体が移動する問題を修正
- テキスト選択などの本来の挙動が優先されるように改善

## Test plan
- [x] テンプレートエディターでノードを追加
- [x] inputフィールドでテキストをドラッグ選択できることを確認
- [x] toggleスイッチを操作してもノードが移動しないことを確認
- [x] ボタンをクリックしてもノードが選択されないことを確認
- [x] ノードのヘッダー部分をドラッグするとノードが移動することを確認（既存動作の維持）

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)