### PR TITLE
fix: ノードが縦長になりすぎる問題を修正

### DIFF
--- a/frontend/src/components/Node/ChangeChannelPermissionNode.tsx
+++ b/frontend/src/components/Node/ChangeChannelPermissionNode.tsx
@@ -16,7 +16,7 @@ import {
   BaseNodeHeaderTitle,
   cn,
 } from "./base-node";
-import { BaseNodeDataSchema, NODE_TYPE_WIDTHS } from "./base-schema";
+import { BaseNodeDataSchema, NODE_CONTENT_HEIGHTS, NODE_TYPE_WIDTHS } from "./base-schema";
 import { useNodeExecutionOptional } from "./NodeExecutionContext";
 
 const RolePermissionSchema = z.object({
@@ -184,7 +184,7 @@ export const ChangeChannelPermissionNode = ({
       <BaseNodeHeader>
         <BaseNodeHeaderTitle>チャンネル権限を変更する</BaseNodeHeaderTitle>
       </BaseNodeHeader>
-      <BaseNodeContent>
+      <BaseNodeContent maxHeight={NODE_CONTENT_HEIGHTS.md}>
         <div className="space-y-3">
           {/* Channel name input */}
           <input

--- a/frontend/src/components/Node/CreateChannelNode.tsx
+++ b/frontend/src/components/Node/CreateChannelNode.tsx
@@ -16,7 +16,7 @@ import {
   BaseNodeHeaderTitle,
   cn,
 } from "./base-node";
-import { BaseNodeDataSchema, NODE_TYPE_WIDTHS } from "./base-schema";
+import { BaseNodeDataSchema, NODE_CONTENT_HEIGHTS, NODE_TYPE_WIDTHS } from "./base-schema";
 import { useNodeExecutionOptional } from "./NodeExecutionContext";
 
 const RolePermissionSchema = z.object({
@@ -226,7 +226,7 @@ export const CreateChannelNode = ({
       <BaseNodeHeader>
         <BaseNodeHeaderTitle>チャンネルを作成する</BaseNodeHeaderTitle>
       </BaseNodeHeader>
-      <BaseNodeContent>
+      <BaseNodeContent maxHeight={NODE_CONTENT_HEIGHTS.lg}>
         <div className="space-y-4">
           {data.channels.map((channel, channelIndex) => (
             <div

--- a/frontend/src/components/Node/CreateRoleNode.tsx
+++ b/frontend/src/components/Node/CreateRoleNode.tsx
@@ -16,7 +16,7 @@ import {
   BaseNodeHeaderTitle,
   cn,
 } from "./base-node";
-import { BaseNodeDataSchema, NODE_TYPE_WIDTHS } from "./base-schema";
+import { BaseNodeDataSchema, NODE_CONTENT_HEIGHTS, NODE_TYPE_WIDTHS } from "./base-schema";
 import { useNodeExecutionOptional } from "./NodeExecutionContext";
 
 export const DataSchema = BaseNodeDataSchema.extend({
@@ -109,7 +109,7 @@ export const CreateRoleNode = ({
       <BaseNodeHeader>
         <BaseNodeHeaderTitle>ロールを作成する</BaseNodeHeaderTitle>
       </BaseNodeHeader>
-      <BaseNodeContent>
+      <BaseNodeContent maxHeight={NODE_CONTENT_HEIGHTS.md}>
         {data.roles.map((role, index) => (
           <div key={`${id}-role-${index}`} className="flex gap-2 items-center mb-2">
             <input

--- a/frontend/src/components/Node/DeleteChannelNode.tsx
+++ b/frontend/src/components/Node/DeleteChannelNode.tsx
@@ -16,7 +16,7 @@ import {
   BaseNodeHeaderTitle,
   cn,
 } from "./base-node";
-import { BaseNodeDataSchema, NODE_TYPE_WIDTHS } from "./base-schema";
+import { BaseNodeDataSchema, NODE_CONTENT_HEIGHTS, NODE_TYPE_WIDTHS } from "./base-schema";
 import { useNodeExecutionOptional } from "./NodeExecutionContext";
 
 export const DataSchema = BaseNodeDataSchema.extend({
@@ -135,7 +135,7 @@ export const DeleteChannelNode = ({
       <BaseNodeHeader>
         <BaseNodeHeaderTitle>チャンネルを削除する</BaseNodeHeaderTitle>
       </BaseNodeHeader>
-      <BaseNodeContent>
+      <BaseNodeContent maxHeight={NODE_CONTENT_HEIGHTS.md}>
         {data.channelNames.map((name, index) => (
           <div key={`${id}-channel-${index}`} className="flex gap-2 items-center mb-2">
             <input

--- a/frontend/src/components/Node/DeleteRoleNode.tsx
+++ b/frontend/src/components/Node/DeleteRoleNode.tsx
@@ -16,7 +16,7 @@ import {
   BaseNodeHeaderTitle,
   cn,
 } from "./base-node";
-import { BaseNodeDataSchema, NODE_TYPE_WIDTHS } from "./base-schema";
+import { BaseNodeDataSchema, NODE_CONTENT_HEIGHTS, NODE_TYPE_WIDTHS } from "./base-schema";
 import { useNodeExecutionOptional } from "./NodeExecutionContext";
 
 export const DataSchema = BaseNodeDataSchema.extend({
@@ -153,7 +153,7 @@ export const DeleteRoleNode = ({
       <BaseNodeHeader>
         <BaseNodeHeaderTitle>ロールを削除する</BaseNodeHeaderTitle>
       </BaseNodeHeader>
-      <BaseNodeContent>
+      <BaseNodeContent maxHeight={NODE_CONTENT_HEIGHTS.sm}>
         <div className="form-control mb-2">
           <label className="nodrag label cursor-pointer justify-start gap-2">
             <input

--- a/frontend/src/components/Node/SendMessageNode.tsx
+++ b/frontend/src/components/Node/SendMessageNode.tsx
@@ -18,7 +18,7 @@ import {
   BaseNodeHeaderTitle,
   cn,
 } from "./base-node";
-import { BaseNodeDataSchema, NODE_TYPE_WIDTHS } from "./base-schema";
+import { BaseNodeDataSchema, NODE_CONTENT_HEIGHTS, NODE_TYPE_WIDTHS } from "./base-schema";
 import { useNodeExecutionOptional } from "./NodeExecutionContext";
 import { useTemplateEditorContextOptional } from "./TemplateEditorContext";
 
@@ -315,7 +315,7 @@ export const SendMessageNode = ({
       <BaseNodeHeader>
         <BaseNodeHeaderTitle>メッセージを送信する</BaseNodeHeaderTitle>
       </BaseNodeHeader>
-      <BaseNodeContent>
+      <BaseNodeContent maxHeight={NODE_CONTENT_HEIGHTS.md}>
         <div className="space-y-3">
           {/* Channel name input */}
           <div>

--- a/frontend/src/components/Node/base-node.tsx
+++ b/frontend/src/components/Node/base-node.tsx
@@ -68,11 +68,16 @@ export function BaseNodeHeaderTitle({ className, ...props }: ComponentProps<"h3"
   );
 }
 
-export function BaseNodeContent({ className, ...props }: ComponentProps<"div">) {
+interface BaseNodeContentProps extends ComponentProps<"div"> {
+  maxHeight?: number;
+}
+
+export function BaseNodeContent({ className, maxHeight, ...props }: BaseNodeContentProps) {
   return (
     <div
       data-slot="base-node-content"
-      className={cn("flex flex-col gap-y-2 p-3", className)}
+      className={cn("flex flex-col gap-y-2 p-3", maxHeight && "overflow-y-auto nowheel", className)}
+      style={maxHeight ? { maxHeight: `${maxHeight}px` } : undefined}
       {...props}
     />
   );

--- a/frontend/src/components/Node/base-schema.ts
+++ b/frontend/src/components/Node/base-schema.ts
@@ -29,3 +29,12 @@ export const NODE_TYPE_WIDTHS: Record<string, NodeWidth> = {
 } as const;
 
 export const DEFAULT_NODE_WIDTH = NODE_WIDTHS.md;
+
+// Node content height constants for scrollable areas
+export const NODE_CONTENT_HEIGHTS = {
+  sm: 200, // Small nodes
+  md: 300, // Standard nodes
+  lg: 400, // Large/complex nodes
+} as const;
+
+export type NodeContentHeight = (typeof NODE_CONTENT_HEIGHTS)[keyof typeof NODE_CONTENT_HEIGHTS];

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -39,3 +39,21 @@ main.padded {
   padding: 1rem;
   /* p-4 */
 }
+
+/* Scrollable node content scrollbar styling */
+[data-slot="base-node-content"]::-webkit-scrollbar {
+  width: 6px;
+}
+
+[data-slot="base-node-content"]::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+[data-slot="base-node-content"]::-webkit-scrollbar-thumb {
+  background-color: oklch(var(--bc) / 0.3);
+  border-radius: 3px;
+}
+
+[data-slot="base-node-content"]::-webkit-scrollbar-thumb:hover {
+  background-color: oklch(var(--bc) / 0.5);
+}


### PR DESCRIPTION
## Summary
- ノードコンテンツに`maxHeight`を設定し、コンテンツがはみ出す場合はスクロール可能にした
- `nowheel`クラスでスクロール時のキャンバスパンを防止
- DaisyUIテーマに合わせたスクロールバースタイルを追加

## Changes
- `BaseNodeContent`に`maxHeight`プロパティを追加
- `NODE_CONTENT_HEIGHTS`定数を追加 (sm: 200px, md: 300px, lg: 400px)
- 各ノードにmaxHeightを適用:
  - CreateChannelNode: lg (400px)
  - CreateRoleNode: md (300px)
  - DeleteChannelNode: md (300px)
  - DeleteRoleNode: sm (200px)
  - ChangeChannelPermissionNode: md (300px)
  - SendMessageNode: md (300px)

## Test plan
- [ ] テンプレートエディタでCreateChannelNodeを作成し、5つ以上のチャンネルを追加
- [ ] コンテンツ領域がスクロール可能であることを確認
- [ ] スクロール時にキャンバスがパンしないことを確認（`nowheel`クラス）
- [ ] フォーム要素の操作中にノードがドラッグされないことを確認（`nodrag`クラス）

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)