### PR TITLE
feat: Add right-click context menu for node creation

### DIFF
--- a/frontend/src/components/Node/CommentNode.tsx
+++ b/frontend/src/components/Node/CommentNode.tsx
@@ -1,14 +1,10 @@
 import type { Node, NodeProps } from "@xyflow/react";
+
 import z from "zod";
 
 import { useTemplateEditorStore } from "@/stores/templateEditorStore";
 
-import {
-  BaseNode,
-  BaseNodeContent,
-  BaseNodeHeader,
-  BaseNodeHeaderTitle,
-} from "./base-node";
+import { BaseNode, BaseNodeContent, BaseNodeHeader, BaseNodeHeaderTitle } from "./base-node";
 import { BaseNodeDataSchema, NODE_TYPE_WIDTHS } from "./base-schema";
 
 export const DataSchema = BaseNodeDataSchema.extend({
@@ -29,10 +25,7 @@ export const CommentNode = ({
   };
 
   return (
-    <BaseNode
-      width={NODE_TYPE_WIDTHS.Comment}
-      className="border-info/50 bg-info/10"
-    >
+    <BaseNode width={NODE_TYPE_WIDTHS.Comment} className="border-info/50 bg-info/10">
       <BaseNodeHeader className="bg-info/20">
         <BaseNodeHeaderTitle>コメント</BaseNodeHeaderTitle>
       </BaseNodeHeader>

--- a/frontend/src/components/Node/LabeledGroupNode.tsx
+++ b/frontend/src/components/Node/LabeledGroupNode.tsx
@@ -1,5 +1,6 @@
-import { type Node, type NodeProps, NodeResizer } from "@xyflow/react";
 import type { ComponentProps, ReactNode } from "react";
+
+import { type Node, type NodeProps, NodeResizer } from "@xyflow/react";
 import z from "zod";
 
 import { useTemplateEditorStore } from "@/stores/templateEditorStore";

--- a/frontend/src/routes/template/$id.tsx
+++ b/frontend/src/routes/template/$id.tsx
@@ -100,6 +100,33 @@ function RouteComponent() {
         <button onClick={handleSave} disabled={!templateName.trim()} className="btn btn-primary">
           保存
         </button>
+        <div className="relative group">
+          <div className="btn btn-ghost btn-circle btn-sm" aria-label="操作ヒント">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+          </div>
+          <div className="absolute right-0 top-full mt-1 hidden group-hover:block z-50 p-4 shadow-lg bg-base-100 rounded-box w-64 border border-base-300">
+            <h4 className="font-bold mb-2">操作ガイド</h4>
+            <ul className="text-sm space-y-1">
+              <li>・右クリックでノードを追加</li>
+              <li>・ノード上で右クリックで複製・削除</li>
+              <li>・ドラッグでノードを移動</li>
+              <li>・ハンドルをドラッグで接続</li>
+            </ul>
+          </div>
+        </div>
       </div>
 
       <div className="flex-1 min-h-0">


### PR DESCRIPTION
## Summary
- キャンバスの空白部分を右クリックすると「ノードを作成する」メニューが表示される
- 右クリック位置にノードが作成される
- 右上の「ノード追加」ボタンを削除し、空状態時にガイドテキストを表示
- ヘッダーにホバーで表示される操作ガイドボタンを追加

## Test plan
- [x] エディタを開き、空白部分を右クリック → 「ノードを作成する」メニューが表示される
- [x] メニューをクリック → ノード選択モーダルが開く
- [x] ノードを選択して追加 → 右クリック位置にノードが作成される
- [x] ノードが0個の状態 → 中央に「右クリックでノードを追加」ガイドが表示される
- [x] ノード上で右クリック → 従来通り「複製」「削除」メニューが表示される
- [x] ヘッダーの「?」ボタンをホバー → 操作ガイドが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)