### PR TITLE
feat: セッション詳細ページでの編集制限 (#32)

### DIFF
--- a/frontend/src/components/Node/AddRoleToRoleMembersNode.tsx
+++ b/frontend/src/components/Node/AddRoleToRoleMembersNode.tsx
@@ -134,7 +134,7 @@ export const AddRoleToRoleMembersNode = ({
             value={data.memberRoleName}
             onChange={(evt) => handleMemberRoleNameChange(evt.target.value)}
             placeholder="例: プレイヤー"
-            disabled={isLoading || isExecuted}
+            disabled={isExecuteMode || isLoading || isExecuted}
           />
         </div>
         <div>
@@ -147,7 +147,7 @@ export const AddRoleToRoleMembersNode = ({
             value={data.addRoleName}
             onChange={(evt) => handleAddRoleNameChange(evt.target.value)}
             placeholder="例: 参加者"
-            disabled={isLoading || isExecuted}
+            disabled={isExecuteMode || isLoading || isExecuted}
           />
         </div>
       </BaseNodeContent>

--- a/frontend/src/components/Node/ChangeChannelPermissionNode.tsx
+++ b/frontend/src/components/Node/ChangeChannelPermissionNode.tsx
@@ -194,7 +194,7 @@ export const ChangeChannelPermissionNode = ({
             value={data.channelName}
             onChange={(evt) => handleChannelNameChange(evt.target.value)}
             placeholder="チャンネル名"
-            disabled={isLoading || isExecuted}
+            disabled={isExecuteMode || isLoading || isExecuted}
           />
 
           {/* Warning message */}
@@ -230,7 +230,7 @@ export const ChangeChannelPermissionNode = ({
                     handleRolePermissionChange(roleIndex, "roleName", e.target.value)
                   }
                   placeholder="ロール名"
-                  disabled={isLoading || isExecuted}
+                  disabled={isExecuteMode || isLoading || isExecuted}
                 />
                 <label className="nodrag flex items-center gap-1 cursor-pointer">
                   <span className="text-xs">読み取り</span>
@@ -241,28 +241,32 @@ export const ChangeChannelPermissionNode = ({
                     onChange={(e) =>
                       handleRolePermissionChange(roleIndex, "canWrite", e.target.checked)
                     }
-                    disabled={isLoading || isExecuted}
+                    disabled={isExecuteMode || isLoading || isExecuted}
                   />
                   <span className="text-xs">書き込み</span>
                 </label>
-                <button
-                  type="button"
-                  className="nodrag btn btn-ghost btn-xs"
-                  onClick={() => handleRemoveRolePermission(roleIndex)}
-                  disabled={isLoading || isExecuted}
-                >
-                  x
-                </button>
+                {!isExecuteMode && (
+                  <button
+                    type="button"
+                    className="nodrag btn btn-ghost btn-xs"
+                    onClick={() => handleRemoveRolePermission(roleIndex)}
+                    disabled={isLoading || isExecuted}
+                  >
+                    x
+                  </button>
+                )}
               </div>
             ))}
-            <button
-              type="button"
-              className="nodrag btn btn-ghost btn-xs"
-              onClick={handleAddRolePermission}
-              disabled={isLoading || isExecuted}
-            >
-              + ロールを追加
-            </button>
+            {!isExecuteMode && (
+              <button
+                type="button"
+                className="nodrag btn btn-ghost btn-xs"
+                onClick={handleAddRolePermission}
+                disabled={isLoading || isExecuted}
+              >
+                + ロールを追加
+              </button>
+            )}
           </div>
 
           {/* Show available roles and channels in execute mode */}

--- a/frontend/src/components/Node/CommentNode.tsx
+++ b/frontend/src/components/Node/CommentNode.tsx
@@ -16,13 +16,15 @@ type CommentNodeData = Node<z.infer<typeof DataSchema>, "Comment">;
 export const CommentNode = ({
   id,
   data,
-  mode: _mode = "edit",
+  mode = "edit",
 }: NodeProps<CommentNodeData> & { mode?: "edit" | "execute" }) => {
   const updateNodeData = useTemplateEditorStore((state) => state.updateNodeData);
 
   const handleCommentChange = (newValue: string) => {
     updateNodeData(id, { comment: newValue });
   };
+
+  const isExecuteMode = mode === "execute";
 
   return (
     <BaseNode width={NODE_TYPE_WIDTHS.Comment} className="border-info/50 bg-info/10">
@@ -36,6 +38,7 @@ export const CommentNode = ({
           value={data.comment}
           onChange={(evt) => handleCommentChange(evt.target.value)}
           placeholder="ワークフローの補足情報を入力..."
+          readOnly={isExecuteMode}
         />
       </BaseNodeContent>
     </BaseNode>

--- a/frontend/src/components/Node/CreateCategoryNode.tsx
+++ b/frontend/src/components/Node/CreateCategoryNode.tsx
@@ -95,7 +95,7 @@ export const CreateCategoryNode = ({
           value={data.categoryName}
           onChange={(evt) => handleCategoryNameChange(evt.target.value)}
           placeholder="カテゴリ名を入力"
-          disabled={isLoading || isExecuted}
+          disabled={isExecuteMode || isLoading || isExecuted}
         />
       </BaseNodeContent>
       {isExecuteMode && (

--- a/frontend/src/components/Node/CreateChannelNode.tsx
+++ b/frontend/src/components/Node/CreateChannelNode.tsx
@@ -241,7 +241,7 @@ export const CreateChannelNode = ({
                   value={channel.name}
                   onChange={(evt) => handleChannelChange(channelIndex, "name", evt.target.value)}
                   placeholder="チャンネル名"
-                  disabled={isLoading || isExecuted}
+                  disabled={isExecuteMode || isLoading || isExecuted}
                 />
                 <label className="nodrag flex items-center gap-1 cursor-pointer">
                   <span className="text-xs">テキスト</span>
@@ -252,18 +252,20 @@ export const CreateChannelNode = ({
                     onChange={(e) =>
                       handleChannelChange(channelIndex, "type", e.target.checked ? "voice" : "text")
                     }
-                    disabled={isLoading || isExecuted}
+                    disabled={isExecuteMode || isLoading || isExecuted}
                   />
                   <span className="text-xs">ボイス</span>
                 </label>
-                <button
-                  type="button"
-                  className="nodrag btn btn-ghost btn-sm"
-                  onClick={() => handleRemoveChannel(channelIndex)}
-                  disabled={isLoading || isExecuted}
-                >
-                  削除
-                </button>
+                {!isExecuteMode && (
+                  <button
+                    type="button"
+                    className="nodrag btn btn-ghost btn-sm"
+                    onClick={() => handleRemoveChannel(channelIndex)}
+                    disabled={isLoading || isExecuted}
+                  >
+                    削除
+                  </button>
+                )}
               </div>
 
               {/* Role permissions */}
@@ -287,7 +289,7 @@ export const CreateChannelNode = ({
                         )
                       }
                       placeholder="ロール名"
-                      disabled={isLoading || isExecuted}
+                      disabled={isExecuteMode || isLoading || isExecuted}
                     />
                     <label className="nodrag flex items-center gap-1 cursor-pointer">
                       <span className="text-xs">読み取り</span>
@@ -303,28 +305,32 @@ export const CreateChannelNode = ({
                             e.target.checked,
                           )
                         }
-                        disabled={isLoading || isExecuted}
+                        disabled={isExecuteMode || isLoading || isExecuted}
                       />
                       <span className="text-xs">書き込み</span>
                     </label>
-                    <button
-                      type="button"
-                      className="nodrag btn btn-ghost btn-xs"
-                      onClick={() => handleRemoveRolePermission(channelIndex, roleIndex)}
-                      disabled={isLoading || isExecuted}
-                    >
-                      ×
-                    </button>
+                    {!isExecuteMode && (
+                      <button
+                        type="button"
+                        className="nodrag btn btn-ghost btn-xs"
+                        onClick={() => handleRemoveRolePermission(channelIndex, roleIndex)}
+                        disabled={isLoading || isExecuted}
+                      >
+                        ×
+                      </button>
+                    )}
                   </div>
                 ))}
-                <button
-                  type="button"
-                  className="nodrag btn btn-ghost btn-xs"
-                  onClick={() => handleAddRolePermission(channelIndex)}
-                  disabled={isLoading || isExecuted}
-                >
-                  + ロールを追加
-                </button>
+                {!isExecuteMode && (
+                  <button
+                    type="button"
+                    className="nodrag btn btn-ghost btn-xs"
+                    onClick={() => handleAddRolePermission(channelIndex)}
+                    disabled={isLoading || isExecuted}
+                  >
+                    + ロールを追加
+                  </button>
+                )}
               </div>
 
               {/* Show available roles in execute mode */}
@@ -337,14 +343,16 @@ export const CreateChannelNode = ({
           ))}
         </div>
 
-        <button
-          type="button"
-          className="nodrag btn btn-ghost btn-sm mt-2"
-          onClick={handleAddChannel}
-          disabled={isLoading || isExecuted}
-        >
-          チャンネルを追加
-        </button>
+        {!isExecuteMode && (
+          <button
+            type="button"
+            className="nodrag btn btn-ghost btn-sm mt-2"
+            onClick={handleAddChannel}
+            disabled={isLoading || isExecuted}
+          >
+            チャンネルを追加
+          </button>
+        )}
 
         {isLoading && (
           <div className="mt-2">

--- a/frontend/src/components/Node/CreateRoleNode.tsx
+++ b/frontend/src/components/Node/CreateRoleNode.tsx
@@ -119,7 +119,7 @@ export const CreateRoleNode = ({
               value={role}
               onChange={(evt) => handleRoleChange(index, evt.target.value)}
               placeholder="ロール名を入力"
-              disabled={isLoading || isExecuted}
+              disabled={isExecuteMode || isLoading || isExecuted}
             />
             {!isExecuteMode && (
               <button

--- a/frontend/src/components/Node/DeleteChannelNode.tsx
+++ b/frontend/src/components/Node/DeleteChannelNode.tsx
@@ -145,7 +145,7 @@ export const DeleteChannelNode = ({
               value={name}
               onChange={(evt) => handleChannelNameChange(index, evt.target.value)}
               placeholder="チャンネル名を入力"
-              disabled={isLoading || isExecuted}
+              disabled={isExecuteMode || isLoading || isExecuted}
             />
             {!isExecuteMode && (
               <button

--- a/frontend/src/components/Node/DeleteRoleNode.tsx
+++ b/frontend/src/components/Node/DeleteRoleNode.tsx
@@ -162,7 +162,7 @@ export const DeleteRoleNode = ({
               className="checkbox"
               checked={data.deleteAll}
               onChange={(e) => handleDeleteAllChange(e.target.checked)}
-              disabled={isLoading || isExecuted}
+              disabled={isExecuteMode || isLoading || isExecuted}
             />
             <span className="label-text">すべて削除</span>
           </label>
@@ -178,7 +178,7 @@ export const DeleteRoleNode = ({
                   value={name}
                   onChange={(evt) => handleRoleNameChange(index, evt.target.value)}
                   placeholder="ロール名を入力"
-                  disabled={isLoading || isExecuted}
+                  disabled={isExecuteMode || isLoading || isExecuted}
                 />
                 {!isExecuteMode && (
                   <button

--- a/frontend/src/components/Node/SendMessageNode.tsx
+++ b/frontend/src/components/Node/SendMessageNode.tsx
@@ -416,7 +416,7 @@ export const SendMessageNode = ({
               value={data.channelName}
               onChange={(e) => handleChannelNameChange(e.target.value)}
               placeholder="チャンネル名"
-              disabled={isLoading || isExecuted}
+              disabled={isExecuteMode || isLoading || isExecuted}
             />
           </div>
 
@@ -433,7 +433,7 @@ export const SendMessageNode = ({
                     {message.content.length}/2000
                   </span>
                 </div>
-                {data.messages.length > 1 && (
+                {!isExecuteMode && data.messages.length > 1 && (
                   <button
                     type="button"
                     className="nodrag btn btn-ghost btn-xs"
@@ -452,7 +452,7 @@ export const SendMessageNode = ({
                 onChange={(e) => handleContentChange(messageIndex, e.target.value)}
                 placeholder="メッセージを入力"
                 maxLength={2000}
-                disabled={isLoading || isExecuted}
+                disabled={isExecuteMode || isLoading || isExecuted}
               />
 
               {/* Attachments for this message */}
@@ -481,14 +481,16 @@ export const SendMessageNode = ({
                             !
                           </span>
                         )}
-                        <button
-                          type="button"
-                          className="nodrag btn btn-ghost btn-xs"
-                          onClick={() => handleFileRemove(messageIndex, fileIndex)}
-                          disabled={isLoading || isExecuted}
-                        >
-                          ×
-                        </button>
+                        {!isExecuteMode && (
+                          <button
+                            type="button"
+                            className="nodrag btn btn-ghost btn-xs"
+                            onClick={() => handleFileRemove(messageIndex, fileIndex)}
+                            disabled={isLoading || isExecuted}
+                          >
+                            ×
+                          </button>
+                        )}
                       </div>
                     ))}
                   </div>
@@ -512,7 +514,7 @@ export const SendMessageNode = ({
                       multiple
                       className="hidden"
                       onChange={(e) => handleFileAdd(messageIndex, e)}
-                      disabled={isLoading || isExecuted}
+                      disabled={isExecuteMode || isLoading || isExecuted}
                     />
                     <div
                       className={cn(
@@ -523,7 +525,7 @@ export const SendMessageNode = ({
                         draggingIndex === messageIndex
                           ? "border-primary bg-primary/10 border-solid"
                           : "border-dashed border-base-content/30 hover:border-base-content/50 hover:bg-base-200/50",
-                        (isLoading || isExecuted) &&
+                        (isExecuteMode || isLoading || isExecuted) &&
                           "opacity-50 pointer-events-none cursor-not-allowed",
                       )}
                       onDragOver={handleDragOver}
@@ -531,6 +533,7 @@ export const SendMessageNode = ({
                       onDragLeave={(e) => handleDragLeave(messageIndex, e)}
                       onDrop={(e) => handleDrop(messageIndex, e)}
                       onClick={() =>
+                        !isExecuteMode &&
                         !isLoading &&
                         !isExecuted &&
                         fileInputRefs.current.get(messageIndex)?.click()
@@ -566,14 +569,16 @@ export const SendMessageNode = ({
           ))}
 
           {/* Add message block button */}
-          <button
-            type="button"
-            className="nodrag btn btn-outline btn-sm w-full"
-            onClick={handleAddMessageBlock}
-            disabled={isLoading || isExecuted}
-          >
-            + メッセージを追加
-          </button>
+          {!isExecuteMode && (
+            <button
+              type="button"
+              className="nodrag btn btn-outline btn-sm w-full"
+              onClick={handleAddMessageBlock}
+              disabled={isLoading || isExecuted}
+            >
+              + メッセージを追加
+            </button>
+          )}
 
           {/* Available channels display (execute mode) */}
           {isExecuteMode && channels.length > 0 && (

--- a/frontend/src/components/Node/SetGameFlagNode.tsx
+++ b/frontend/src/components/Node/SetGameFlagNode.tsx
@@ -112,7 +112,7 @@ export const SetGameFlagNode = ({
             value={data.flagKey}
             onChange={(evt) => handleKeyChange(evt.target.value)}
             placeholder="例: アイテム入手, イベント発生済み"
-            disabled={isLoading || isExecuted}
+            disabled={isExecuteMode || isLoading || isExecuted}
           />
         </label>
         <label className="form-control w-full">
@@ -125,7 +125,7 @@ export const SetGameFlagNode = ({
             value={data.flagValue}
             onChange={(evt) => handleValueChange(evt.target.value)}
             placeholder="例: 1, アイテム名"
-            disabled={isLoading || isExecuted}
+            disabled={isExecuteMode || isLoading || isExecuted}
           />
         </label>
       </BaseNodeContent>

--- a/frontend/src/components/TemplateEditor.tsx
+++ b/frontend/src/components/TemplateEditor.tsx
@@ -368,14 +368,14 @@ const TemplateEditorContent = ({
         onReconnect={onReconnect}
         onReconnectEnd={onReconnectEnd}
         onMoveEnd={handleMoveEnd}
-        onNodeContextMenu={handleNodeContextMenu}
-        onPaneContextMenu={handlePaneContextMenu}
+        onNodeContextMenu={mode === "edit" ? handleNodeContextMenu : undefined}
+        onPaneContextMenu={mode === "edit" ? handlePaneContextMenu : undefined}
         onPaneClick={handlePaneClick}
         defaultViewport={storeViewport}
       >
         <Controls />
         <Background variant={BackgroundVariant.Dots} />
-        {storeNodes.length === 0 && (
+        {storeNodes.length === 0 && mode === "edit" && (
           <Panel position="top-center" className="mt-20">
             <div className="text-base-content/50 text-center">
               <p className="text-lg">右クリックでノードを追加</p>


### PR DESCRIPTION
## Summary

- セッション詳細ページ（executeモード）で、ワークフローの構造を変更する編集操作を制限
- テンプレート詳細ページ（editモード）でのみ編集可能に

## Changes

### 入力フィールドの無効化
全ノードの入力フィールドに`isExecuteMode`条件を追加し、executeモードでは編集不可に

### 追加/削除ボタンの非表示
`{!isExecuteMode && (...)}` でラップし、executeモードでは非表示に

### コンテキストメニューの無効化
`TemplateEditor.tsx`でノード・ペインのコンテキストメニューをeditモードのみに制限

### 対象ノード
- CommentNode
- CreateRoleNode
- CreateCategoryNode
- CreateChannelNode
- SendMessageNode
- DeleteRoleNode
- DeleteChannelNode
- ChangeChannelPermissionNode
- AddRoleToRoleMembersNode
- SetGameFlagNode

## Test plan

- [x] セッション詳細ページで各ノードの入力フィールドが編集不可であることを確認
- [x] セッション詳細ページで追加/削除ボタンが非表示であることを確認
- [x] セッション詳細ページで右クリックメニューが表示されないことを確認
- [x] セッション詳細ページで実行ボタンが正常に動作することを確認
- [x] テンプレート詳細ページですべての編集機能が正常に動作することを確認

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)