### PR TITLE
docs: Add developer documentation for node system architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,12 @@
 
 プロジェクトの詳細な設計ドキュメントは `/docs` ディレクトリに保存されています：
 
+### ユーザー向けドキュメント (`/docs`)
 - [ノードベースワークフローシステム設計書](docs/node-workflow-system.md) - TRPG/マーダーミステリーセッション管理のための、ノードベースワークフローシステムの設計
+
+### 開発者向けドキュメント (`/docs/dev`)
+- [ノードシステムアーキテクチャ](docs/dev/node-system-architecture.md) - **新しいノードを実装する際は必ず参照**。ノードの基本構造、実装パターン、チェックリストを含む
+- [RecordCombinationNode設計書](docs/dev/record-combination-node.md) - 組み合わせ記録ノードの設計（Issue #23）
 
 ## Project Architecture
 
@@ -111,6 +116,16 @@ fish -c "bun run type-check"
 # Run tests
 fish -c "bun run test"
 ```
+
+## Development Workflow
+
+**重要**: コードを実装した後は、必ず以下のコマンドを順番に実行してエラーがないことを確認する：
+
+1. `fish -c "bun run type-check"` - 型エラーがないことを確認
+2. `fish -c "bun run format"` - コードをフォーマット
+3. `fish -c "bun run lint"` - lint エラーがないことを確認
+
+すべてのコマンドが成功するまで、実装は完了とみなさない。
 
 ## Testing
 

--- a/docs/dev/node-system-architecture.md
+++ b/docs/dev/node-system-architecture.md
@@ -1,0 +1,457 @@
+# ノードベースワークフローシステム アーキテクチャ
+
+> このドキュメントは、新しいノードタイプを実装する際の参照用です。
+
+## 概要
+
+このプロジェクトは、TRPG/マーダーミステリーセッション管理のためのノードベースワークフローシステムを実装しています。React Flow (@xyflow/react) を使用し、ノードの編集（テンプレート作成）と実行（セッション管理）の2つのモードをサポートします。
+
+---
+
+## 既存ノードタイプ一覧
+
+| ノードタイプ | 役割 | 幅 |
+|-------------|------|-----|
+| CreateCategory | Discord カテゴリを作成 | md (256px) |
+| CreateRole | Discord ロールを複数作成 | md |
+| CreateChannel | テキスト/ボイスチャンネル作成＆権限設定 | lg (480px) |
+| DeleteCategory | カテゴリの削除 | md |
+| DeleteRole | ロール削除（全体または指定） | md |
+| DeleteChannel | チャンネル削除（指定名） | md |
+| ChangeChannelPermission | チャンネル権限を更新 | md |
+| AddRoleToRoleMembers | ロールメンバーに別のロール付与 | md |
+| SendMessage | チャンネルへメッセージ送信＆ファイル添付 | lg |
+| Blueprint | マーダーミステリー基本セット（展開ノード） | lg |
+| SetGameFlag | セッションのゲームフラグ設定 | md |
+| LabeledGroup | ノードをグループ化するコンテナ | xl (640px) |
+| Comment | ワークフロー内のコメント | md |
+
+---
+
+## ノードの基本構造
+
+### ベーススキーマ
+
+すべてのノードは `BaseNodeDataSchema` を拡張します。
+
+```typescript
+// frontend/src/components/Node/base-schema.ts
+export const BaseNodeDataSchema = z.object({
+  executedAt: z.coerce.date().optional(),  // 実行完了時刻
+});
+```
+
+### ノード幅の定義
+
+```typescript
+export const NODE_WIDTHS = {
+  sm: 192,  // 12 × 16px
+  md: 256,  // 16 × 16px（標準）
+  lg: 480,  // 30 × 16px（複雑なノード用）
+  xl: 640,  // 40 × 16px（グループノード用）
+} as const;
+
+export const NODE_TYPE_WIDTHS: Record<string, NodeWidth> = {
+  CreateRole: NODE_WIDTHS.md,
+  CreateChannel: NODE_WIDTHS.lg,
+  // ... 新しいノードもここに追加
+};
+```
+
+### コンテンツ高さの定義
+
+```typescript
+export const NODE_CONTENT_HEIGHTS = {
+  sm: 200,  // 小さいノード
+  md: 300,  // 標準ノード
+  lg: 400,  // 大きい/複雑なノード
+} as const;
+```
+
+---
+
+## ノードコンポーネントの実装パターン
+
+### 基本構造
+
+```typescript
+// frontend/src/components/Node/ExampleNode.tsx
+import { Position, type Node, type NodeProps } from "@xyflow/react";
+import { useState } from "react";
+import z from "zod";
+
+import { useTemplateEditorStore } from "@/stores/templateEditorStore";
+import { useToast } from "@/toast/ToastProvider";
+
+import {
+  BaseHandle,
+  BaseNode,
+  BaseNodeContent,
+  BaseNodeFooter,
+  BaseNodeHeader,
+  BaseNodeHeaderTitle,
+  cn,
+} from "./base-node";
+import { BaseNodeDataSchema, NODE_CONTENT_HEIGHTS, NODE_TYPE_WIDTHS } from "./base-schema";
+import { useNodeExecutionOptional } from "./NodeExecutionContext";
+
+// 1. スキーマ定義
+export const DataSchema = BaseNodeDataSchema.extend({
+  // ノード固有のデータフィールド
+  myField: z.string(),
+});
+
+type ExampleNodeData = Node<z.infer<typeof DataSchema>, "Example">;
+
+// 2. コンポーネント定義
+export const ExampleNode = ({
+  id,
+  data,
+  mode = "edit",
+}: NodeProps<ExampleNodeData> & { mode?: "edit" | "execute" }) => {
+  const updateNodeData = useTemplateEditorStore((state) => state.updateNodeData);
+  const executionContext = useNodeExecutionOptional();
+  const { addToast } = useToast();
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  // 3. データ更新ハンドラ
+  const handleFieldChange = (newValue: string) => {
+    updateNodeData(id, { myField: newValue });
+  };
+
+  // 4. 実行ハンドラ（execute mode用）
+  const handleExecute = async () => {
+    if (!executionContext) {
+      addToast({ message: "実行コンテキストがありません", status: "error" });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      // Discord API呼び出しなど
+      // await client.doSomething();
+
+      // 成功時
+      updateNodeData(id, { executedAt: new Date() });
+      addToast({ message: "実行完了", status: "success" });
+    } catch (error) {
+      addToast({ message: "実行失敗", status: "error" });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const isExecuteMode = mode === "execute";
+  const isExecuted = !!data.executedAt;
+
+  // 5. レンダリング
+  return (
+    <BaseNode
+      width={NODE_TYPE_WIDTHS.Example}
+      className={cn("bg-base-300", data.executedAt && "border-success bg-success/10")}
+    >
+      <BaseNodeHeader>
+        <BaseNodeHeaderTitle>ノードタイトル</BaseNodeHeaderTitle>
+      </BaseNodeHeader>
+
+      <BaseNodeContent maxHeight={NODE_CONTENT_HEIGHTS.md}>
+        {/* Edit mode: 編集可能なフォーム */}
+        {/* Execute mode: 読み取り専用の表示 */}
+        <input
+          type="text"
+          className="nodrag input input-bordered w-full"
+          value={data.myField}
+          onChange={(e) => handleFieldChange(e.target.value)}
+          disabled={isExecuteMode || isLoading || isExecuted}
+        />
+      </BaseNodeContent>
+
+      {/* Execute mode時のみフッター表示 */}
+      {isExecuteMode && (
+        <BaseNodeFooter>
+          <button
+            type="button"
+            className="nodrag btn btn-primary"
+            onClick={handleExecute}
+            disabled={isLoading || isExecuted}
+          >
+            {isLoading && <span className="loading loading-spinner loading-sm" />}
+            実行
+          </button>
+        </BaseNodeFooter>
+      )}
+
+      {/* 接続ハンドル */}
+      <BaseHandle id="target-1" type="target" position={Position.Top} />
+      <BaseHandle id="source-1" type="source" position={Position.Bottom} />
+    </BaseNode>
+  );
+};
+```
+
+---
+
+## UIコンポーネント
+
+### BaseNode コンポーネント群
+
+```typescript
+// frontend/src/components/Node/base-node.tsx
+export function BaseNode({ className, width, style, ...props })
+export function BaseNodeHeader({ className, ...props })
+export function BaseNodeHeaderTitle({ className, ...props })
+export function BaseNodeContent({ className, maxHeight, ...props })
+export function BaseNodeFooter({ className, ...props })
+export function BaseHandle({ className, ...props })
+export function LabeledHandle({ title, position, ...props })
+```
+
+### 重要なクラス
+
+- `nodrag`: React Flow のドラッグを無効化（input要素などに必須）
+- `bg-base-300`: 標準の背景色
+- `border-success bg-success/10`: 実行完了時のスタイル
+
+---
+
+## Edit Mode vs Execute Mode
+
+| 観点 | Edit Mode | Execute Mode |
+|------|-----------|--------------|
+| 用途 | テンプレート設計時 | セッション実行時 |
+| データ編集 | 可能 | 不可（表示のみ） |
+| 実行ボタン | 非表示 | 表示 |
+| 削除ボタン | 表示 | 非表示 |
+| 実行コンテキスト | なし | あり（guildId, sessionId, bot等） |
+
+### 実行コンテキスト
+
+```typescript
+// frontend/src/components/Node/NodeExecutionContext.tsx
+interface NodeExecutionContextValue {
+  guildId: string;
+  sessionId: number;
+  sessionName: string;
+  bot: DiscordBotData;
+}
+```
+
+---
+
+## ストア統合
+
+### templateEditorStore.ts への追加手順
+
+1. **型のインポート**
+```typescript
+import type { DataSchema as ExampleDataSchema } from "@/components/Node/ExampleNode";
+```
+
+2. **型定義の追加**
+```typescript
+export type ExampleNodeData = z.infer<typeof ExampleDataSchema>;
+```
+
+3. **FlowNode union型への追加**
+```typescript
+export type FlowNode =
+  | Node<ExampleNodeData, "Example">
+  | // ... 既存の型
+```
+
+4. **addNode関数への追加**
+```typescript
+} else if (type === "Example") {
+  newNode = {
+    id,
+    type,
+    position,
+    data: {
+      // デフォルト値
+      myField: "",
+    },
+  };
+}
+```
+
+5. **updateNodeData の型にも追加**
+```typescript
+updateNodeData: (
+  nodeId: string,
+  data: Partial<
+    | ExampleNodeData
+    | // ... 既存の型
+  >,
+) => void;
+```
+
+6. **addNode の type 引数にも追加**
+```typescript
+addNode: (
+  type:
+    | "Example"
+    | // ... 既存の型
+  position: { x: number; y: number },
+) => void;
+```
+
+---
+
+## node-wrapper.tsx への登録
+
+```typescript
+// frontend/src/components/Node/node-wrapper.tsx
+import { ExampleNode } from "./ExampleNode";
+
+export function createNodeTypes(mode: "edit" | "execute" = "edit"): NodeTypes {
+  const ExampleWithMode: ComponentType<NodeProps<any>> = (props) => (
+    <ExampleNode {...props} mode={mode} />
+  );
+
+  return {
+    Example: ExampleWithMode,
+    // ... 既存のノード
+  };
+}
+```
+
+---
+
+## TemplateEditor.tsx への追加
+
+```typescript
+// frontend/src/components/TemplateEditor.tsx
+const NODE_CATEGORIES = [
+  {
+    category: "カテゴリ名",
+    nodes: [
+      { type: "Example", label: "サンプルノード" },
+      // ...
+    ],
+  },
+  // ...
+] as const;
+```
+
+---
+
+## 新しいノード実装のチェックリスト
+
+1. [ ] `frontend/src/components/Node/NewNode.tsx` を作成
+   - DataSchema を定義
+   - コンポーネントを実装
+2. [ ] `frontend/src/components/Node/base-schema.ts` に幅を追加
+   - `NODE_TYPE_WIDTHS` に追加
+3. [ ] `frontend/src/components/Node/node-wrapper.tsx` に登録
+   - インポート追加
+   - `createNodeTypes` 関数内で mode を注入
+4. [ ] `frontend/src/stores/templateEditorStore.ts` を更新
+   - 型インポート
+   - 型定義追加
+   - FlowNode union型に追加
+   - addNode 関数に初期データ追加
+   - updateNodeData の型に追加
+5. [ ] `frontend/src/components/TemplateEditor.tsx` に追加
+   - `NODE_CATEGORIES` に追加
+6. [ ] `frontend/src/components/Node/index.ts` にエクスポート追加（必要に応じて）
+
+---
+
+## DynamicValue システム
+
+ノードのパラメータを動的に解決するシステム。
+
+```typescript
+// frontend/src/components/Node/DynamicValue.ts
+export const DynamicValueSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("literal"), value: z.string() }),
+  z.object({ type: z.literal("session.name") }),
+]);
+
+export function resolveDynamicValue(
+  value: DynamicValue,
+  context: { sessionName?: string },
+): string {
+  switch (value.type) {
+    case "literal":
+      return value.value;
+    case "session.name":
+      return context.sessionName ?? "";
+  }
+}
+```
+
+**使用例（CreateCategoryNode）:**
+```typescript
+export const DataSchema = BaseNodeDataSchema.extend({
+  categoryName: DynamicValueSchema,
+});
+```
+
+---
+
+## データ永続化
+
+### ReactFlowData
+
+```typescript
+export const ReactFlowDataSchema = z.object({
+  nodes: z.array(z.any()),
+  edges: z.array(z.any()),
+  viewport: z.object({
+    x: z.number(),
+    y: z.number(),
+    zoom: z.number(),
+  }),
+});
+```
+
+- ノードデータは `GameSession.reactFlowData` に JSON 文字列として保存
+- Dexie.js (IndexedDB) を使用
+
+---
+
+## 実行フロー
+
+1. **検証**: 入力データチェック
+2. **解決**: ロール名→ID変換など参照データ取得
+3. **API呼び出し**: Discord API を通じて実行
+4. **DB保存**: 作成したリソース情報を DB に記録
+5. **ステート更新**: `executedAt` タイムスタンプを設定
+6. **トースト通知**: 実行結果をユーザーに通知
+
+### プログレス表示パターン
+
+```typescript
+const [progress, setProgress] = useState({ current: 0, total: 0 });
+
+// ループ処理中
+for (let i = 0; i < items.length; i++) {
+  setProgress({ current: i + 1, total: items.length });
+  // 処理
+}
+
+// UI
+{isLoading && (
+  <progress
+    className="progress progress-primary w-full"
+    value={progress.current}
+    max={progress.total}
+  />
+)}
+```
+
+---
+
+## 関連ファイル
+
+| ファイル | 説明 |
+|---------|------|
+| `frontend/src/components/Node/base-node.tsx` | UIプリミティブ |
+| `frontend/src/components/Node/base-schema.ts` | 共通スキーマ・定数 |
+| `frontend/src/components/Node/node-wrapper.tsx` | ノードタイプ登録 |
+| `frontend/src/components/Node/NodeExecutionContext.tsx` | 実行コンテキスト |
+| `frontend/src/components/Node/DynamicValue.ts` | 動的値システム |
+| `frontend/src/stores/templateEditorStore.ts` | Zustandストア |
+| `frontend/src/components/TemplateEditor.tsx` | エディタ本体 |

--- a/docs/dev/record-combination-node.md
+++ b/docs/dev/record-combination-node.md
@@ -1,0 +1,227 @@
+# 組み合わせ記録ノード (RecordCombinationNode) 設計書
+
+> GitHub Issue: https://github.com/bi9dri/gm-assistant-bot/issues/23
+> 作成日: 2026-01-21
+
+## 概要
+
+TRPG/マーダーミステリーセッション管理で使用する「組み合わせを記録するノード」を実装する。
+
+### ユースケース
+1. **密談記録**: キャラクター同士の1対1密談ペアを順番に記録
+2. **探索割当記録**: キャラクター→場所のマッピングを記録
+
+### 4つのパターン
+| # | パターン | 例 |
+|---|---------|---|
+| 1 | キャラ-キャラ（自分自身NG、重複禁止） | 密談順番記録 |
+| 2 | キャラ-キャラ（自分自身NG、重複OK） | 何度も密談可能な場合 |
+| 3 | キャラ→場所（異なる集合間、重複禁止） | 1人1場所のみ探索 |
+| 4 | キャラ→場所（異なる集合間、重複OK） | 1人が複数場所探索可能 |
+
+---
+
+## 設計方針
+
+### ノード構成: 単一ノード + モード切替（推奨）
+
+**理由**:
+- 既存パターン（DynamicValueの`type`による分岐）に沿っている
+- 4つのパターンは本質的に同じ「組み合わせ記録」の変種
+- 将来の拡張（キャラ-アイテム等）に対応しやすい
+- プリセット（密談記録/探索割当）でUXをカバー
+
+---
+
+## データスキーマ
+
+```typescript
+// 選択肢
+const OptionItemSchema = z.object({
+  id: z.string(),      // UUID
+  label: z.string(),   // 表示名
+});
+
+// 記録されたペア
+const RecordedPairSchema = z.object({
+  id: z.string(),
+  sourceId: z.string(),
+  targetId: z.string(),
+  recordedAt: z.coerce.date(),  // タイムライン表示用
+  memo: z.string().optional(),  // 将来拡張用
+});
+
+// 設定
+const PairingConfigSchema = z.object({
+  mode: z.enum(["same-set", "different-set"]),
+  allowSelfPairing: z.boolean().default(false),
+  allowDuplicates: z.boolean().default(false),
+  directionality: z.enum(["undirected", "directed"]).default("directed"),
+  allowMultipleAssignments: z.boolean().default(false),
+});
+
+// メインスキーマ
+export const DataSchema = BaseNodeDataSchema.extend({
+  title: z.string().default("組み合わせを記録"),
+  config: PairingConfigSchema,
+  sourceOptions: z.object({
+    label: z.string().default("キャラクター"),
+    items: z.array(OptionItemSchema),
+  }),
+  targetOptions: z.object({
+    label: z.string().default("場所"),
+    items: z.array(OptionItemSchema),
+  }).optional(),  // different-setモードのみ使用
+  recordedPairs: z.array(RecordedPairSchema).default([]),
+});
+```
+
+### 設定の対応表
+| パターン | mode | allowSelfPairing | allowDuplicates | directionality |
+|---------|------|------------------|-----------------|----------------|
+| 密談（重複禁止） | same-set | false | false | directed |
+| 密談（重複OK） | same-set | false | true | directed |
+| 探索（1人1場所） | different-set | - | false | - |
+| 探索（1人複数場所） | different-set | - | true | - |
+
+---
+
+## UI設計
+
+### Edit Mode
+```
+┌─────────────────────────────────────────┐
+│ [タイトル入力: 密談記録             ]    │
+│ プリセット: [▼ 密談記録]                 │
+├─────────────────────────────────────────┤
+│ 設定                             [▼]    │
+│  モード: ○同一集合 ○異なる集合           │
+│  □ 重複ペアを許可                        │
+│  方向性: ○無向(A-B) ○有向(A→B)          │
+├─────────────────────────────────────────┤
+│ キャラクター                             │
+│  [田中太郎    ] [削除]                   │
+│  [佐藤花子    ] [削除]                   │
+│  [+ 追加]                               │
+└─────────────────────────────────────────┘
+```
+
+### Execute Mode
+```
+┌─────────────────────────────────────────┐
+│ 密談記録                                 │
+├─────────────────────────────────────────┤
+│ [▼ キャラ1] → [▼ キャラ2]               │
+│         [記録する]                       │
+├─────────────────────────────────────────┤
+│ 記録履歴 (3件)                           │
+│ 1. 田中太郎 → 佐藤花子    14:30:25      │
+│ 2. 鈴木一郎 → 田中太郎    14:31:10      │
+│ 3. 佐藤花子 → 鈴木一郎    14:32:45      │
+└─────────────────────────────────────────┘
+```
+
+### 動的フィルタリング
+- 左側で選択した項目は右側から除外（allowSelfPairing: false時）
+- 記録済みペアは右側でグレーアウト表示（allowDuplicates: false時）
+
+---
+
+## 実装ステップ
+
+### Phase 1 (MVP): 密談記録の基本機能
+1. [ ] `RecordCombinationNode.tsx` - スキーマ定義 + メインコンポーネント
+2. [ ] `OptionListEditor.tsx` - 選択肢の追加/削除/編集UI
+3. [ ] `PairingInputForm.tsx` - ペア入力フォーム（ドロップダウン×2）
+4. [ ] `useFilteredOptions.ts` - 自分自身除外の動的フィルタリング
+5. [ ] `PairingTimeline.tsx` - シンプルなリスト表示
+6. [ ] ストア統合（templateEditorStore.ts）
+7. [ ] NODE_CATEGORIESへの追加
+8. [ ] node-wrapper.tsxへの登録
+
+### Phase 2: 探索割当対応
+- [ ] different-setモード対応（ターゲット選択肢）
+- [ ] 詳細設定UI（directionality, allowMultipleAssignments）
+- [ ] プリセット機能
+- [ ] 重複時のグレーアウト表示
+
+### Phase 3: UX改善
+- [ ] メモ機能
+- [ ] 削除/修正機能
+- [ ] エクスポート機能
+
+---
+
+## 変更対象ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `frontend/src/components/Node/RecordCombinationNode.tsx` | 新規作成: メインコンポーネント + スキーマ |
+| `frontend/src/components/Node/RecordCombinationNode/*.tsx` | 新規作成: サブコンポーネント群 |
+| `frontend/src/components/Node/hooks/useFilteredOptions.ts` | 新規作成: フィルタリングロジック |
+| `frontend/src/components/Node/hooks/usePairingValidation.ts` | 新規作成: 検証ロジック |
+| `frontend/src/components/Node/base-schema.ts` | NODE_TYPE_WIDTHSに `RecordCombination: NODE_WIDTHS.lg` 追加 |
+| `frontend/src/components/Node/node-wrapper.tsx` | createNodeTypes関数への登録 |
+| `frontend/src/stores/templateEditorStore.ts` | FlowNode型 + addNode関数の拡張 |
+| `frontend/src/components/TemplateEditor.tsx` | NODE_CATEGORIESの「ゲーム管理」カテゴリに追加 |
+
+### templateEditorStore.ts への追加内容
+
+```typescript
+// import追加
+import type { DataSchema as RecordCombinationDataSchema } from "@/components/Node/RecordCombinationNode";
+
+// 型定義追加
+export type RecordCombinationNodeData = z.infer<typeof RecordCombinationDataSchema>;
+
+// FlowNode union型への追加
+| Node<RecordCombinationNodeData, "RecordCombination">
+
+// addNode関数への追加
+} else if (type === "RecordCombination") {
+  newNode = {
+    id,
+    type,
+    position,
+    data: {
+      title: "組み合わせを記録",
+      config: {
+        mode: "same-set",
+        allowSelfPairing: false,
+        allowDuplicates: false,
+        directionality: "directed",
+        allowMultipleAssignments: false,
+      },
+      sourceOptions: {
+        label: "キャラクター",
+        items: [],
+      },
+      recordedPairs: [],
+    },
+  };
+}
+```
+
+### TemplateEditor.tsx NODE_CATEGORIESへの追加
+
+```typescript
+{
+  category: "ゲーム管理",
+  nodes: [
+    { type: "SetGameFlag", label: "ゲームフラグを設定する" },
+    { type: "RecordCombination", label: "組み合わせを記録する" },  // 追加
+  ],
+},
+```
+
+---
+
+## 検証方法
+
+1. テンプレートエディタでRecordCombinationノードを追加できる
+2. Edit modeでキャラクター名を入力できる
+3. Execute modeでペアを選択・記録できる
+4. 自分自身とのペアが作れないことを確認
+5. 重複禁止設定時、既存ペアがグレーアウトされることを確認
+6. タイムラインに記録順で表示されることを確認
+7. セッションを保存・再読み込みしてもデータが保持されることを確認


### PR DESCRIPTION
## Summary
- ノードシステムアーキテクチャの開発者向けドキュメントを追加
- RecordCombinationNode（Issue #23）の設計書を追加
- CLAUDE.mdに開発ドキュメントへの参照と開発ワークフローを追加

## Changes
- `docs/dev/node-system-architecture.md` - 新しいノードを実装する際の参照ドキュメント
- `docs/dev/record-combination-node.md` - 組み合わせ記録ノードの設計書
- `CLAUDE.md` - 開発者向けドキュメントセクションと開発ワークフローを追加

## Test plan
- [x] ドキュメントの内容が正確であることを確認
- [x] リンクが正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)