### PR TITLE
docs: Add node-creator skill instruction to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,10 @@
 - [ノードシステムアーキテクチャ](docs/dev/node-system-architecture.md) - **新しいノードを実装する際は必ず参照**。ノードの基本構造、実装パターン、チェックリストを含む
 - [RecordCombinationNode設計書](docs/dev/record-combination-node.md) - 組み合わせ記録ノードの設計（Issue #23）
 
+### Skills（Claude Code スキル）
+- **node-creator**: 新しいノードタイプ（`XxxNode`）を実装する際は、**必ずこのスキルを利用すること**。スキルには実装チェックリスト、コンポーネントテンプレート、登録手順が含まれている。
+  - トリガー例: 「新しいノードを作成」「XxxNode を実装」「ノードタイプを追加」
+
 ## Project Architecture
 
 This is a single-page application (SPA) project with client-side Discord integration.


### PR DESCRIPTION
## Summary
- CLAUDE.md に node-creator スキルの必須利用指示を追加
- 新しい NodeType を実装する際に、スキルの利用を必須とする

## Test plan
- [x] CLAUDE.md のフォーマットが正しいことを確認
- [x] 新しい会話で「新しいノードを作成して」などのリクエストを試し、スキルが呼び出されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)