### PR TITLE
feat: Add template resource reference system for workflow nodes

### DIFF
--- a/docs/dev/template-resource-reference.md
+++ b/docs/dev/template-resource-reference.md
@@ -1,0 +1,207 @@
+# 実装計画: Issue #31 & #35 - テンプレートリソース参照
+
+## 概要
+
+### Issue #31: テンプレート詳細ページで作成されうるロールなどを一覧して、各ノードで参照できるようにする
+テンプレート編集モードで、前のノードで作成されるリソース（ロール、チャンネル）を参照できるようにする。
+
+### Issue #35: ノードから GameFlags などにアクセスできるようにする
+DynamicValueシステムを拡張し、GameFlagsやセッションリソースへの参照をサポートする。
+
+> **Note**: メッセージ補間機能（`{flag:key}` 構文）は別PRで実装予定
+
+---
+
+## 実装フェーズ
+
+### Phase 1: DynamicValue スキーマ拡張
+
+**ファイル**: `frontend/src/components/Node/utils/DynamicValue.ts`
+
+現在のスキーマに以下の参照タイプを追加:
+
+```typescript
+export const DynamicValueSchema = z.discriminatedUnion("type", [
+  // 既存
+  z.object({ type: z.literal("literal"), value: z.string() }),
+  z.object({ type: z.literal("session.name") }),
+  // 新規追加
+  z.object({ type: z.literal("roleRef"), roleName: z.string() }),
+  z.object({ type: z.literal("channelRef"), channelName: z.string() }),
+  z.object({ type: z.literal("gameFlag"), flagKey: z.string() }),
+]);
+```
+
+`resolveDynamicValue` 関数のコンテキストを拡張:
+```typescript
+export interface DynamicValueContext {
+  sessionName?: string;
+  roles?: Map<string, string>;      // roleName -> roleId
+  channels?: Map<string, string>;   // channelName -> channelId
+  gameFlags?: Record<string, string>;
+}
+```
+
+---
+
+### Phase 2: テンプレートリソース収集Hook
+
+**新規ファイル**: `frontend/src/components/Node/utils/useTemplateResources.ts`
+
+ワークフローグラフを解析し、指定ノードより前に作成されるリソースを収集:
+
+```typescript
+export interface TemplateResources {
+  roles: Array<{ name: string; sourceNodeId: string }>;
+  channels: Array<{ name: string; type: "text" | "voice"; sourceNodeId: string }>;
+  gameFlags: Array<{ key: string; sourceNodeId: string }>;
+}
+
+export function useTemplateResources(nodeId: string): TemplateResources;
+```
+
+**収集ロジック**:
+1. エッジを逆方向にたどり、対象ノードより前の全ノードを特定
+2. CreateRoleNode → `roles` を抽出
+3. CreateChannelNode → `channels` を抽出
+4. SetGameFlagNode → `gameFlags` を抽出
+
+---
+
+### Phase 3: ResourceSelector コンポーネント
+
+**新規ファイル**: `frontend/src/components/Node/utils/ResourceSelector.tsx`
+
+ロール/チャンネル選択用のドロップダウンコンポーネント:
+
+```typescript
+interface ResourceSelectorProps {
+  nodeId: string;
+  resourceType: "role" | "channel" | "gameFlag";
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  allowCustom?: boolean;
+  channelTypeFilter?: "text" | "voice";
+}
+```
+
+**動作**:
+- 利用可能なリソースがある場合: ドロップダウン表示
+- リソースがない場合/カスタム入力: テキストフィールド表示
+- 切り替えボタンでモード変更可能
+
+---
+
+### Phase 4: DynamicValueInput 拡張
+
+**ファイル**: `frontend/src/components/Node/utils/DynamicValueInput.tsx`
+
+新しい参照タイプに対応:
+
+```typescript
+interface DynamicValueInputProps {
+  nodeId: string;  // 追加
+  value: DynamicValue;
+  onChange: (value: DynamicValue) => void;
+  supportedTypes?: Array<"literal" | "session.name" | "roleRef" | "channelRef" | "gameFlag">;
+  // ...
+}
+```
+
+---
+
+### Phase 5: ノードコンポーネント更新
+
+#### 5.1 CreateChannelNode
+**ファイル**: `frontend/src/components/Node/nodes/CreateChannelNode.tsx`
+
+ロール権限入力をResourceSelectorに変更:
+- `roleName` テキスト入力 → ResourceSelector
+
+#### 5.2 SendMessageNode
+**ファイル**: `frontend/src/components/Node/nodes/SendMessageNode.tsx`
+
+- チャンネル名入力 → ResourceSelector
+
+#### 5.3 ChangeChannelPermissionNode
+**ファイル**: `frontend/src/components/Node/nodes/ChangeChannelPermissionNode.tsx`
+
+- チャンネル名、ロール名入力 → ResourceSelector
+
+#### 5.4 その他のノード
+- AddRoleToRoleMembersNode
+- DeleteRoleNode
+- DeleteChannelNode
+
+---
+
+## 修正対象ファイル一覧
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `frontend/src/components/Node/utils/DynamicValue.ts` | スキーマ拡張、コンテキスト型定義 |
+| `frontend/src/components/Node/utils/DynamicValueInput.tsx` | 新参照タイプ対応、nodeId prop追加 |
+| `frontend/src/components/Node/utils/useTemplateResources.ts` | **新規作成** |
+| `frontend/src/components/Node/utils/ResourceSelector.tsx` | **新規作成** |
+| `frontend/src/components/Node/utils/index.ts` | エクスポート追加 |
+| `frontend/src/components/Node/nodes/CreateChannelNode.tsx` | ResourceSelector使用 |
+| `frontend/src/components/Node/nodes/SendMessageNode.tsx` | ResourceSelector使用 |
+| `frontend/src/components/Node/nodes/ChangeChannelPermissionNode.tsx` | ResourceSelector使用 |
+| `frontend/src/components/Node/nodes/AddRoleToRoleMembersNode.tsx` | ResourceSelector使用 |
+| `frontend/src/components/Node/nodes/DeleteRoleNode.tsx` | ResourceSelector使用 |
+| `frontend/src/components/Node/nodes/DeleteChannelNode.tsx` | ResourceSelector使用 |
+
+---
+
+## 後方互換性
+
+- 既存の `literal` / `session.name` タイプは変更なし
+- 既存テンプレートのデータ移行は不要（新タイプは追加のみ）
+- リソースが見つからない場合は名前をそのまま使用（フォールバック）
+
+---
+
+## 検証方法
+
+1. **編集モードでのリソース参照**
+   - CreateRoleNode を追加 → CreateChannelNode のロール選択に表示されるか確認
+   - SetGameFlagNode を追加 → 他ノードでGameFlag参照が可能か確認
+
+2. **実行モードでの解決**
+   - 参照が実際のDiscordリソースIDに解決されるか確認
+
+3. **エッジケース**
+   - 接続されていないノードのリソースは表示されないこと
+   - 循環参照があっても無限ループしないこと
+
+---
+
+## 実装順序
+
+1. Phase 1: DynamicValue スキーマ拡張
+2. Phase 2: useTemplateResources Hook
+3. Phase 3: ResourceSelector コンポーネント
+4. Phase 4: DynamicValueInput 拡張
+5. Phase 5: 各ノードコンポーネント更新
+6. テスト・検証
+
+---
+
+## 別PRで実装予定
+
+### メッセージ補間機能
+SendMessageNodeのメッセージ本文で `{flag:key}` 構文によるGameFlags値の埋め込み機能は別PRで実装する。
+
+```typescript
+// 将来の実装
+export function interpolateMessage(
+  content: string,
+  gameFlags: Record<string, string>,
+): string {
+  return content.replace(/\{flag:([^}]+)\}/g, (match, key) => {
+    return gameFlags[key.trim()] ?? match;
+  });
+}
+```

--- a/frontend/src/components/Node/nodes/AddRoleToRoleMembersNode.tsx
+++ b/frontend/src/components/Node/nodes/AddRoleToRoleMembersNode.tsx
@@ -19,6 +19,7 @@ import {
   NODE_TYPE_WIDTHS,
 } from "../base";
 import { useNodeExecutionOptional } from "../contexts";
+import { ResourceSelector } from "../utils";
 
 export const DataSchema = BaseNodeDataSchema.extend({
   memberRoleName: z.string().trim(),
@@ -129,11 +130,11 @@ export const AddRoleToRoleMembersNode = ({
           <label className="label py-1">
             <span className="label-text text-xs">対象メンバーのロール名</span>
           </label>
-          <input
-            type="text"
-            className="nodrag input input-bordered w-full"
+          <ResourceSelector
+            nodeId={id}
+            resourceType="role"
             value={data.memberRoleName}
-            onChange={(evt) => handleMemberRoleNameChange(evt.target.value)}
+            onChange={handleMemberRoleNameChange}
             placeholder="例: プレイヤー"
             disabled={isExecuteMode || isLoading || isExecuted}
           />
@@ -142,11 +143,11 @@ export const AddRoleToRoleMembersNode = ({
           <label className="label py-1">
             <span className="label-text text-xs">付与するロール名</span>
           </label>
-          <input
-            type="text"
-            className="nodrag input input-bordered w-full"
+          <ResourceSelector
+            nodeId={id}
+            resourceType="role"
             value={data.addRoleName}
-            onChange={(evt) => handleAddRoleNameChange(evt.target.value)}
+            onChange={handleAddRoleNameChange}
             placeholder="例: 参加者"
             disabled={isExecuteMode || isLoading || isExecuted}
           />

--- a/frontend/src/components/Node/nodes/ChangeChannelPermissionNode.tsx
+++ b/frontend/src/components/Node/nodes/ChangeChannelPermissionNode.tsx
@@ -20,6 +20,7 @@ import {
   NODE_TYPE_WIDTHS,
 } from "../base";
 import { useNodeExecutionOptional } from "../contexts";
+import { ResourceSelector } from "../utils";
 
 const RolePermissionSchema = z.object({
   roleName: z.string().trim(),
@@ -190,11 +191,11 @@ export const ChangeChannelPermissionNode = ({
       <BaseNodeContent maxHeight={NODE_CONTENT_HEIGHTS.md}>
         <div className="space-y-3">
           {/* Channel name input */}
-          <input
-            type="text"
-            className="nodrag input input-bordered input-sm w-full"
+          <ResourceSelector
+            nodeId={id}
+            resourceType="channel"
             value={data.channelName}
-            onChange={(evt) => handleChannelNameChange(evt.target.value)}
+            onChange={handleChannelNameChange}
             placeholder="チャンネル名"
             disabled={isExecuteMode || isLoading || isExecuted}
           />
@@ -224,16 +225,17 @@ export const ChangeChannelPermissionNode = ({
             <p className="text-xs font-semibold">ロール権限</p>
             {data.rolePermissions.map((perm, roleIndex) => (
               <div key={`${id}-role-${roleIndex}`} className="flex gap-2 items-center">
-                <input
-                  type="text"
-                  className="nodrag input input-bordered input-xs flex-1"
-                  value={perm.roleName}
-                  onChange={(e) =>
-                    handleRolePermissionChange(roleIndex, "roleName", e.target.value)
-                  }
-                  placeholder="ロール名"
-                  disabled={isExecuteMode || isLoading || isExecuted}
-                />
+                <div className="flex-1">
+                  <ResourceSelector
+                    nodeId={id}
+                    resourceType="role"
+                    value={perm.roleName}
+                    onChange={(name) => handleRolePermissionChange(roleIndex, "roleName", name)}
+                    placeholder="ロール名"
+                    disabled={isExecuteMode || isLoading || isExecuted}
+                    className="input-xs"
+                  />
+                </div>
                 <label className="nodrag flex items-center gap-1 cursor-pointer">
                   <span className="text-xs">読み取り</span>
                   <input

--- a/frontend/src/components/Node/nodes/CreateCategoryNode.tsx
+++ b/frontend/src/components/Node/nodes/CreateCategoryNode.tsx
@@ -121,6 +121,7 @@ export const CreateCategoryNode = ({
       </BaseNodeHeader>
       <BaseNodeContent>
         <DynamicValueInput
+          nodeId={id}
           value={data.categoryName ?? defaultDynamicValue()}
           onChange={handleCategoryNameChange}
           placeholder="カテゴリ名を入力"

--- a/frontend/src/components/Node/nodes/CreateChannelNode.tsx
+++ b/frontend/src/components/Node/nodes/CreateChannelNode.tsx
@@ -20,6 +20,7 @@ import {
   NODE_TYPE_WIDTHS,
 } from "../base";
 import { useNodeExecutionOptional } from "../contexts";
+import { ResourceSelector } from "../utils";
 
 const RolePermissionSchema = z.object({
   roleName: z.string().trim(),
@@ -278,21 +279,19 @@ export const CreateChannelNode = ({
                     key={`${id}-channel-${channelIndex}-role-${roleIndex}`}
                     className="flex gap-2 items-center"
                   >
-                    <input
-                      type="text"
-                      className="nodrag input input-bordered input-xs flex-1"
-                      value={perm.roleName}
-                      onChange={(e) =>
-                        handleRolePermissionChange(
-                          channelIndex,
-                          roleIndex,
-                          "roleName",
-                          e.target.value,
-                        )
-                      }
-                      placeholder="ロール名"
-                      disabled={isExecuteMode || isLoading || isExecuted}
-                    />
+                    <div className="flex-1">
+                      <ResourceSelector
+                        nodeId={id}
+                        resourceType="role"
+                        value={perm.roleName}
+                        onChange={(name) =>
+                          handleRolePermissionChange(channelIndex, roleIndex, "roleName", name)
+                        }
+                        placeholder="ロール名"
+                        disabled={isExecuteMode || isLoading || isExecuted}
+                        className="input-xs"
+                      />
+                    </div>
                     <label className="nodrag flex items-center gap-1 cursor-pointer">
                       <span className="text-xs">読み取り</span>
                       <input

--- a/frontend/src/components/Node/nodes/DeleteChannelNode.tsx
+++ b/frontend/src/components/Node/nodes/DeleteChannelNode.tsx
@@ -20,6 +20,7 @@ import {
   NODE_TYPE_WIDTHS,
 } from "../base";
 import { useNodeExecutionOptional } from "../contexts";
+import { ResourceSelector } from "../utils";
 
 export const DataSchema = BaseNodeDataSchema.extend({
   channelNames: z.array(z.string().trim()),
@@ -141,14 +142,16 @@ export const DeleteChannelNode = ({
       <BaseNodeContent maxHeight={NODE_CONTENT_HEIGHTS.md}>
         {data.channelNames.map((name, index) => (
           <div key={`${id}-channel-${index}`} className="flex gap-2 items-center mb-2">
-            <input
-              type="text"
-              className="nodrag input input-bordered w-full"
-              value={name}
-              onChange={(evt) => handleChannelNameChange(index, evt.target.value)}
-              placeholder="チャンネル名を入力"
-              disabled={isExecuteMode || isLoading || isExecuted}
-            />
+            <div className="flex-1">
+              <ResourceSelector
+                nodeId={id}
+                resourceType="channel"
+                value={name}
+                onChange={(newName) => handleChannelNameChange(index, newName)}
+                placeholder="チャンネル名を入力"
+                disabled={isExecuteMode || isLoading || isExecuted}
+              />
+            </div>
             {!isExecuteMode && (
               <button
                 type="button"

--- a/frontend/src/components/Node/nodes/DeleteRoleNode.tsx
+++ b/frontend/src/components/Node/nodes/DeleteRoleNode.tsx
@@ -20,6 +20,7 @@ import {
   NODE_TYPE_WIDTHS,
 } from "../base";
 import { useNodeExecutionOptional } from "../contexts";
+import { ResourceSelector } from "../utils";
 
 export const DataSchema = BaseNodeDataSchema.extend({
   deleteAll: z.boolean(),
@@ -174,14 +175,16 @@ export const DeleteRoleNode = ({
           <>
             {data.roleNames.map((name, index) => (
               <div key={`${id}-role-${index}`} className="flex gap-2 items-center mb-2">
-                <input
-                  type="text"
-                  className="nodrag input input-bordered w-full"
-                  value={name}
-                  onChange={(evt) => handleRoleNameChange(index, evt.target.value)}
-                  placeholder="ロール名を入力"
-                  disabled={isExecuteMode || isLoading || isExecuted}
-                />
+                <div className="flex-1">
+                  <ResourceSelector
+                    nodeId={id}
+                    resourceType="role"
+                    value={name}
+                    onChange={(newName) => handleRoleNameChange(index, newName)}
+                    placeholder="ロール名を入力"
+                    disabled={isExecuteMode || isLoading || isExecuted}
+                  />
+                </div>
                 {!isExecuteMode && (
                   <button
                     type="button"

--- a/frontend/src/components/Node/nodes/SendMessageNode.tsx
+++ b/frontend/src/components/Node/nodes/SendMessageNode.tsx
@@ -20,6 +20,7 @@ import {
 } from "../base";
 import { BaseNodeDataSchema, NODE_CONTENT_HEIGHTS, NODE_TYPE_WIDTHS } from "../base";
 import { useNodeExecutionOptional, useTemplateEditorContextOptional } from "../contexts";
+import { ResourceSelector } from "../utils";
 
 const AttachmentSchema = z.object({
   fileName: z.string(),
@@ -409,13 +410,14 @@ export const SendMessageNode = ({
           {/* Channel name input */}
           <div>
             <label className="text-xs font-semibold mb-1 block">送信先チャンネル</label>
-            <input
-              type="text"
-              className="nodrag input input-bordered input-sm w-full"
+            <ResourceSelector
+              nodeId={id}
+              resourceType="channel"
               value={data.channelName}
-              onChange={(e) => handleChannelNameChange(e.target.value)}
+              onChange={handleChannelNameChange}
               placeholder="チャンネル名"
               disabled={isExecuteMode || isLoading || isExecuted}
+              channelTypeFilter="text"
             />
           </div>
 

--- a/frontend/src/components/Node/utils/DynamicValue.ts
+++ b/frontend/src/components/Node/utils/DynamicValue.ts
@@ -3,24 +3,37 @@ import z from "zod";
 export const DynamicValueSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("literal"), value: z.string() }),
   z.object({ type: z.literal("session.name") }),
+  z.object({ type: z.literal("roleRef"), roleName: z.string() }),
+  z.object({ type: z.literal("channelRef"), channelName: z.string() }),
+  z.object({ type: z.literal("gameFlag"), flagKey: z.string() }),
 ]);
 
 export type DynamicValue = z.infer<typeof DynamicValueSchema>;
+
+export interface DynamicValueContext {
+  sessionName?: string;
+  roles?: Map<string, string>;
+  channels?: Map<string, string>;
+  gameFlags?: Record<string, string>;
+}
 
 export const defaultDynamicValue = (): DynamicValue => ({
   type: "literal",
   value: "",
 });
 
-export function resolveDynamicValue(
-  value: DynamicValue,
-  context: { sessionName?: string },
-): string {
+export function resolveDynamicValue(value: DynamicValue, context: DynamicValueContext): string {
   switch (value.type) {
     case "literal":
       return value.value;
     case "session.name":
       return context.sessionName ?? "";
+    case "roleRef":
+      return context.roles?.get(value.roleName) ?? value.roleName;
+    case "channelRef":
+      return context.channels?.get(value.channelName) ?? value.channelName;
+    case "gameFlag":
+      return context.gameFlags?.[value.flagKey] ?? "";
     default:
       return "";
   }

--- a/frontend/src/components/Node/utils/DynamicValueInput.tsx
+++ b/frontend/src/components/Node/utils/DynamicValueInput.tsx
@@ -1,47 +1,75 @@
 import type { DynamicValue } from "./DynamicValue";
 
 import { useNodeExecutionOptional } from "../contexts";
+import { ResourceSelector } from "./ResourceSelector";
+
+type SupportedType = "literal" | "session.name" | "roleRef" | "channelRef" | "gameFlag";
 
 interface DynamicValueInputProps {
+  nodeId: string;
   value: DynamicValue;
   onChange: (value: DynamicValue) => void;
   placeholder?: string;
   disabled?: boolean;
+  supportedTypes?: SupportedType[];
+  channelTypeFilter?: "text" | "voice";
 }
 
+const TYPE_LABELS: Record<SupportedType, string> = {
+  literal: "固定値",
+  "session.name": "セッション名",
+  roleRef: "ロール参照",
+  channelRef: "チャンネル参照",
+  gameFlag: "ゲームフラグ",
+};
+
 export const DynamicValueInput = ({
+  nodeId,
   value,
   onChange,
   placeholder,
   disabled,
+  supportedTypes = ["literal", "session.name"],
+  channelTypeFilter,
 }: DynamicValueInputProps) => {
   const executionContext = useNodeExecutionOptional();
 
+  const handleTypeChange = (newType: SupportedType) => {
+    switch (newType) {
+      case "literal":
+        onChange({ type: "literal", value: "" });
+        break;
+      case "session.name":
+        onChange({ type: "session.name" });
+        break;
+      case "roleRef":
+        onChange({ type: "roleRef", roleName: "" });
+        break;
+      case "channelRef":
+        onChange({ type: "channelRef", channelName: "" });
+        break;
+      case "gameFlag":
+        onChange({ type: "gameFlag", flagKey: "" });
+        break;
+    }
+  };
+
   return (
     <div className="flex flex-col gap-2 w-full">
-      <div className="flex gap-2">
-        <label className="label cursor-pointer gap-1 p-0">
-          <input
-            type="radio"
-            name="value-type"
-            className="nodrag radio radio-xs"
-            checked={value.type === "literal"}
-            onChange={() => onChange({ type: "literal", value: "" })}
-            disabled={disabled}
-          />
-          <span className="label-text text-xs">固定値</span>
-        </label>
-        <label className="label cursor-pointer gap-1 p-0">
-          <input
-            type="radio"
-            name="value-type"
-            className="nodrag radio radio-xs"
-            checked={value.type === "session.name"}
-            onChange={() => onChange({ type: "session.name" })}
-            disabled={disabled}
-          />
-          <span className="label-text text-xs">セッション名</span>
-        </label>
+      <div className="flex flex-wrap gap-2">
+        {supportedTypes.map((type) => (
+          <label key={type} className="label cursor-pointer gap-1 p-0">
+            <input
+              type="radio"
+              name={`value-type-${nodeId}`}
+              className="nodrag radio radio-xs"
+              checked={value.type === type}
+              onChange={() => handleTypeChange(type)}
+              disabled={disabled}
+            />
+            <span className="label-text text-xs">{TYPE_LABELS[type]}</span>
+          </label>
+        ))}
       </div>
 
       {value.type === "literal" && (
@@ -54,10 +82,45 @@ export const DynamicValueInput = ({
           disabled={disabled}
         />
       )}
+
       {value.type === "session.name" && executionContext && (
         <span className="text-sm text-base-content/70 truncate">
           → {executionContext.sessionName}
         </span>
+      )}
+
+      {value.type === "roleRef" && (
+        <ResourceSelector
+          nodeId={nodeId}
+          resourceType="role"
+          value={value.roleName}
+          onChange={(name) => onChange({ type: "roleRef", roleName: name })}
+          placeholder="ロール名を選択"
+          disabled={disabled}
+        />
+      )}
+
+      {value.type === "channelRef" && (
+        <ResourceSelector
+          nodeId={nodeId}
+          resourceType="channel"
+          value={value.channelName}
+          onChange={(name) => onChange({ type: "channelRef", channelName: name })}
+          placeholder="チャンネル名を選択"
+          disabled={disabled}
+          channelTypeFilter={channelTypeFilter}
+        />
+      )}
+
+      {value.type === "gameFlag" && (
+        <ResourceSelector
+          nodeId={nodeId}
+          resourceType="gameFlag"
+          value={value.flagKey}
+          onChange={(key) => onChange({ type: "gameFlag", flagKey: key })}
+          placeholder="フラグキーを選択"
+          disabled={disabled}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/Node/utils/ResourceSelector.tsx
+++ b/frontend/src/components/Node/utils/ResourceSelector.tsx
@@ -1,0 +1,135 @@
+import { useMemo } from "react";
+import { LuPencil, LuChevronDown } from "react-icons/lu";
+
+import { PortaledSelect } from "./PortaledSelect";
+import { useTemplateResources } from "./useTemplateResources";
+
+interface ResourceSelectorProps {
+  nodeId: string;
+  resourceType: "role" | "channel" | "gameFlag";
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  allowCustom?: boolean;
+  channelTypeFilter?: "text" | "voice";
+  className?: string;
+}
+
+export function ResourceSelector({
+  nodeId,
+  resourceType,
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  allowCustom = true,
+  channelTypeFilter,
+  className,
+}: ResourceSelectorProps) {
+  const resources = useTemplateResources(nodeId);
+
+  const options = useMemo(() => {
+    let items: Array<{ name: string; sourceNodeId: string }> = [];
+
+    switch (resourceType) {
+      case "role":
+        items = resources.roles;
+        break;
+      case "channel":
+        items = channelTypeFilter
+          ? resources.channels.filter((c) => c.type === channelTypeFilter)
+          : resources.channels;
+        break;
+      case "gameFlag":
+        items = resources.gameFlags.map((f) => ({ name: f.key, sourceNodeId: f.sourceNodeId }));
+        break;
+    }
+
+    // Deduplicate by name
+    const seen = new Set<string>();
+    const unique: typeof items = [];
+    for (const item of items) {
+      if (!seen.has(item.name)) {
+        seen.add(item.name);
+        unique.push(item);
+      }
+    }
+
+    return unique.map((item) => ({
+      id: item.name,
+      label: item.name,
+    }));
+  }, [resources, resourceType, channelTypeFilter]);
+
+  const hasOptions = options.length > 0;
+
+  // If no options available, always show text input
+  if (!hasOptions) {
+    return (
+      <input
+        type="text"
+        className={`nodrag input input-bordered input-sm w-full ${className ?? ""}`}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+      />
+    );
+  }
+
+  // Check if current value is in the options list
+  const isValueInOptions = options.some((opt) => opt.id === value);
+
+  // If value is not in options and allowCustom, show text input with switch button
+  if (!isValueInOptions && value !== "" && allowCustom) {
+    return (
+      <div className="flex gap-1 items-center w-full">
+        <input
+          type="text"
+          className={`nodrag input input-bordered input-sm flex-1 ${className ?? ""}`}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          disabled={disabled}
+        />
+        <button
+          type="button"
+          className="nodrag btn btn-ghost btn-sm btn-square"
+          onClick={() => onChange("")}
+          title="リストから選択"
+          disabled={disabled}
+        >
+          <LuChevronDown className="w-4 h-4" />
+        </button>
+      </div>
+    );
+  }
+
+  // Show dropdown with options
+  return (
+    <div className="flex gap-1 items-center w-full">
+      <div className="flex-1">
+        <PortaledSelect
+          options={options}
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          disabled={disabled}
+          className={`w-full ${className ?? ""}`}
+        />
+      </div>
+      {allowCustom && (
+        <button
+          type="button"
+          className="nodrag btn btn-ghost btn-sm btn-square"
+          onClick={() => onChange(value || "")}
+          title="カスタム入力"
+          disabled={disabled}
+        >
+          <LuPencil className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Node/utils/index.ts
+++ b/frontend/src/components/Node/utils/index.ts
@@ -1,6 +1,7 @@
 export {
   DynamicValueSchema,
   type DynamicValue,
+  type DynamicValueContext,
   defaultDynamicValue,
   resolveDynamicValue,
 } from "./DynamicValue";
@@ -8,3 +9,12 @@ export {
 export { DynamicValueInput } from "./DynamicValueInput";
 
 export { PortaledSelect } from "./PortaledSelect";
+
+export { ResourceSelector } from "./ResourceSelector";
+
+export {
+  useTemplateResources,
+  useAllTemplateResources,
+  collectResourcesBeforeNode,
+  type TemplateResources,
+} from "./useTemplateResources";

--- a/frontend/src/components/Node/utils/useTemplateResources.ts
+++ b/frontend/src/components/Node/utils/useTemplateResources.ts
@@ -1,0 +1,142 @@
+import type { Edge } from "@xyflow/react";
+
+import { useMemo } from "react";
+
+import { useTemplateEditorStore, type FlowNode } from "@/stores/templateEditorStore";
+
+import type { DynamicValue } from "./DynamicValue";
+
+export interface TemplateResources {
+  roles: Array<{ name: string; sourceNodeId: string }>;
+  channels: Array<{ name: string; type: "text" | "voice"; sourceNodeId: string }>;
+  gameFlags: Array<{ key: string; sourceNodeId: string }>;
+}
+
+/**
+ * Collects all resources that would be available before a specific node executes.
+ * Traverses the graph backwards from the target node to find all predecessor nodes.
+ */
+export function collectResourcesBeforeNode(
+  targetNodeId: string,
+  nodes: FlowNode[],
+  edges: Edge[],
+): TemplateResources {
+  const resources: TemplateResources = {
+    roles: [],
+    channels: [],
+    gameFlags: [],
+  };
+
+  const predecessors = new Set<string>();
+  const visited = new Set<string>();
+  const queue = [targetNodeId];
+
+  const incomingEdges = new Map<string, string[]>();
+  for (const edge of edges) {
+    const existing = incomingEdges.get(edge.target) ?? [];
+    existing.push(edge.source);
+    incomingEdges.set(edge.target, existing);
+  }
+
+  while (queue.length > 0) {
+    const currentId = queue.shift()!;
+    if (visited.has(currentId)) continue;
+    visited.add(currentId);
+
+    const incoming = incomingEdges.get(currentId) ?? [];
+    for (const sourceId of incoming) {
+      predecessors.add(sourceId);
+      queue.push(sourceId);
+    }
+  }
+
+  for (const node of nodes) {
+    if (!predecessors.has(node.id)) continue;
+
+    if (node.type === "CreateRole") {
+      const data = node.data as { roles: string[] };
+      for (const roleName of data.roles) {
+        if (roleName.trim()) {
+          resources.roles.push({ name: roleName.trim(), sourceNodeId: node.id });
+        }
+      }
+    } else if (node.type === "CreateChannel") {
+      const data = node.data as { channels: Array<{ name: string; type: "text" | "voice" }> };
+      for (const channel of data.channels) {
+        if (channel.name.trim()) {
+          resources.channels.push({
+            name: channel.name.trim(),
+            type: channel.type,
+            sourceNodeId: node.id,
+          });
+        }
+      }
+    } else if (node.type === "SetGameFlag") {
+      const data = node.data as { flagKey: string };
+      if (data.flagKey.trim()) {
+        resources.gameFlags.push({ key: data.flagKey.trim(), sourceNodeId: node.id });
+      }
+    }
+  }
+
+  return resources;
+}
+
+/**
+ * Hook to get available resources for the current node.
+ */
+export function useTemplateResources(nodeId: string): TemplateResources {
+  const nodes = useTemplateEditorStore((state) => state.nodes);
+  const edges = useTemplateEditorStore((state) => state.edges);
+
+  return useMemo(() => collectResourcesBeforeNode(nodeId, nodes, edges), [nodeId, nodes, edges]);
+}
+
+/**
+ * Hook to get ALL resources in the template (for overview/validation).
+ */
+export function useAllTemplateResources(): TemplateResources {
+  const nodes = useTemplateEditorStore((state) => state.nodes);
+
+  return useMemo(() => {
+    const resources: TemplateResources = {
+      roles: [],
+      channels: [],
+      gameFlags: [],
+    };
+
+    for (const node of nodes) {
+      if (node.type === "CreateRole") {
+        const data = node.data as { roles: string[] };
+        for (const roleName of data.roles) {
+          if (roleName.trim()) {
+            resources.roles.push({ name: roleName.trim(), sourceNodeId: node.id });
+          }
+        }
+      } else if (node.type === "CreateChannel") {
+        const data = node.data as { channels: Array<{ name: string; type: "text" | "voice" }> };
+        for (const channel of data.channels) {
+          if (channel.name.trim()) {
+            resources.channels.push({
+              name: channel.name.trim(),
+              type: channel.type,
+              sourceNodeId: node.id,
+            });
+          }
+        }
+      } else if (node.type === "CreateCategory") {
+        const data = node.data as { categoryName: DynamicValue };
+        if (data.categoryName.type === "literal" && data.categoryName.value.trim()) {
+          // Category is not tracked in TemplateResources currently
+        }
+      } else if (node.type === "SetGameFlag") {
+        const data = node.data as { flagKey: string };
+        if (data.flagKey.trim()) {
+          resources.gameFlags.push({ key: data.flagKey.trim(), sourceNodeId: node.id });
+        }
+      }
+    }
+
+    return resources;
+  }, [nodes]);
+}


### PR DESCRIPTION
## Summary
- ワークフロー内の先行ノードで作成されるロール・チャンネル・ゲームフラグを、後続ノードから参照できるようにした（Issue #31, #35 対応）
- DynamicValueスキーマを拡張し、新しい参照型（roleRef, channelRef, gameFlag）を追加
- useTemplateResourcesフックとResourceSelectorコンポーネントを新規作成
- 各種ノードコンポーネント（CreateChannelNode, SendMessageNode等）を更新

## Test plan
- [x] テンプレートエディタでCreateRoleNodeの後にCreateChannelNodeを配置し、ロール権限でドロップダウンから先行ノードのロールを選択できることを確認
- [x] セッション実行モードで、参照されたロール名が正しく解決されチャンネルが作成できることを確認
- [x] type-check, format, lint が全て通過することを確認

Closes #31
Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)