### PR TITLE
fix: Add null check for modal checkbox in SessionCard delete handler

### DIFF
--- a/frontend/src/components/SessionCard.tsx
+++ b/frontend/src/components/SessionCard.tsx
@@ -27,8 +27,10 @@ export const SessionCard = ({ id, name, guildId, lastUsedAt }: Props) => {
       const fileSystem = new FileSystem();
       await fileSystem.clearSessionFiles(id);
 
-      const checkbox = document.getElementById(`confirmDeleteModal-${id}`) as HTMLInputElement;
-      checkbox.checked = false;
+      const checkbox = document.getElementById(
+        `confirmDeleteModal-${id}`,
+      ) as HTMLInputElement | null;
+      if (checkbox) checkbox.checked = false;
       addToast({
         message: "セッションを削除しました",
         durationSeconds: 10,


### PR DESCRIPTION
## Summary
- セッション削除時に `Cannot set properties of null (setting 'checked')` エラーが発生する問題を修正
- `useLiveQuery()` の再評価でコンポーネントが DOM から削除された後にチェックボックスにアクセスしようとするのが原因
- TemplateCard と BotCard で既に使用されている null チェックパターンに統一

## Test plan
- [x] セッション一覧ページでセッションを削除
- [x] エラートーストが表示されないことを確認
- [x] 「セッションを削除しました」トーストが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)