### PR TITLE
fix: Apply DaisyUI theme colors to error toast

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -57,3 +57,10 @@ main.padded {
 [data-slot="base-node-content"]::-webkit-scrollbar-thumb:hover {
   background-color: oklch(var(--bc) / 0.5);
 }
+
+/* Error toast custom styling using theme colors */
+.toast .alert-error {
+  background-color: var(--color-error);
+  border-color: var(--color-error);
+  color: var(--color-error-content);
+}


### PR DESCRIPTION
## Summary
- エラートーストにDaisyUIのテーマカラー変数を適用
- `--color-error` と `--color-error-content` を使用し、全テーマで適切な視認性を確保

## Test plan
- [x] 開発サーバーを起動してエラートーストを表示
- [x] 複数のテーマで色が連動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)