### PR TITLE
feat(session): Add auto-save with visual indicator in execute mode

### DIFF
--- a/frontend/src/hooks/useAutoSave.ts
+++ b/frontend/src/hooks/useAutoSave.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { GameSession } from "@/db";
+import { useTemplateEditorStore } from "@/stores/templateEditorStore";
+
+interface UseAutoSaveOptions {
+  sessionId: number | undefined;
+  enabled: boolean;
+  debounceMs?: number;
+  showSavedDurationMs?: number;
+}
+
+interface UseAutoSaveReturn {
+  showSaved: boolean;
+}
+
+export function useAutoSave({
+  sessionId,
+  enabled,
+  debounceMs = 500,
+  showSavedDurationMs = 2000,
+}: UseAutoSaveOptions): UseAutoSaveReturn {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const savedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isSavingRef = useRef(false);
+  const [showSaved, setShowSaved] = useState(false);
+
+  const save = useCallback(async () => {
+    if (!sessionId || isSavingRef.current) return;
+
+    try {
+      isSavingRef.current = true;
+      const { nodes, edges, viewport } = useTemplateEditorStore.getState();
+      const session = await GameSession.getById(sessionId);
+      if (session) {
+        await session.update({ reactFlowData: { nodes, edges, viewport } });
+
+        // 保存完了インジケーターを表示
+        setShowSaved(true);
+        if (savedTimeoutRef.current) {
+          clearTimeout(savedTimeoutRef.current);
+        }
+        savedTimeoutRef.current = setTimeout(() => {
+          setShowSaved(false);
+        }, showSavedDurationMs);
+      }
+    } catch (error) {
+      console.error("Auto-save failed:", error);
+    } finally {
+      isSavingRef.current = false;
+    }
+  }, [sessionId, showSavedDurationMs]);
+
+  useEffect(() => {
+    if (!enabled || !sessionId) return;
+
+    const unsubscribe = useTemplateEditorStore.subscribe((state, prevState) => {
+      // nodes または edges が変更された場合のみトリガー
+      if (state.nodes === prevState.nodes && state.edges === prevState.edges) {
+        return;
+      }
+
+      // 既存の timeout をクリア
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      // 新しい debounce タイマーを設定
+      timeoutRef.current = setTimeout(save, debounceMs);
+    });
+
+    return () => {
+      unsubscribe();
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [sessionId, enabled, debounceMs, save]);
+
+  return { showSaved };
+}


### PR DESCRIPTION
## Summary
- セッション実行モードで自動保存機能を追加
- 500ms debounce で nodes/edges の変更を検知して自動保存
- 保存完了時に「✓ 保存しました」インジケーターを2秒間表示

## Test plan
- [x] セッションページでノードを移動し、自動保存されることを確認
- [x] ノードデータを変更し、自動保存されることを確認
- [x] 連続して変更しても、debounce により適切に保存されることを確認
- [x] 保存完了インジケーターが表示・非表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)