### PR TITLE
Simplify SelectBranchNode by using label as value

### DIFF
--- a/frontend/src/stores/templateEditorStore.ts
+++ b/frontend/src/stores/templateEditorStore.ts
@@ -309,10 +309,10 @@ export const useTemplateEditorStore = create<TemplateEditorStore>((set, get) => 
         data: {
           title: "選択肢を選ぶ",
           options: [
-            { id: crypto.randomUUID(), label: "", value: "" },
-            { id: crypto.randomUUID(), label: "", value: "" },
+            { id: crypto.randomUUID(), label: "" },
+            { id: crypto.randomUUID(), label: "" },
           ],
-          resultFlagKey: "",
+          flagName: "",
         },
       };
     } else {


### PR DESCRIPTION
## Summary
- `resultFlagKey` → `flagName` に変更（使い方がより明確に）
- 選択肢の `value` フィールドを削除し、ラベル＝値としてシンプル化
- UIから値の入力欄を削除（ラベル1つだけで管理）

## Test plan
- [ ] 既存のSelectBranchNodeが正しく動作することを確認
- [ ] 新規作成したSelectBranchNodeで選択肢の追加・削除ができることを確認
- [ ] 実行モードで選択肢を選んで保存できることを確認
- [ ] フラグ名に保存した値が正しく反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)