### PR TITLE
Bunコマンドの実行方法を統一

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,9 @@
 ### Runtime and Package Manager
 - Default to using **Bun** instead of Node.js
 - Use `bun <file>` instead of `node <file>` or `ts-node <file>`
-- Use `bun test` instead of `jest` or `vitest`
+- Use `bun run --bun test` instead of `jest` or `vitest`
 - Use `bun install` instead of `npm install` or `yarn install` or `pnpm install`
-- Use `bun run <script>` instead of `npm run <script>` or `yarn run <script>` or `pnpm run <script>`
+- Use `bun run --bun <script>` instead of `npm run <script>` or `yarn run <script>` or `pnpm run <script>`
 - Bun automatically loads .env, so don't use dotenv
 
 ### Dependency Management
@@ -65,28 +65,28 @@ Bun workspaceを使用したモノレポ構成。
 ルートディレクトリから実行:
 
 ```bash
-bun dev         # 開発サーバー起動 (frontend: 3000, backend: 8787)
-bun build       # ビルド
-bun deploy      # Cloudflare Workersにデプロイ
-bun lint        # リンティング
-bun format      # フォーマット
-bun type-check  # 型チェック
-bun test        # テスト
+bun run --bun dev         # 開発サーバー起動 (frontend: 3000, backend: 8787)
+bun run --bun build       # ビルド
+bun run --bun deploy      # Cloudflare Workersにデプロイ
+bun run --bun lint        # リンティング
+bun run --bun format      # フォーマット
+bun run --bun type-check  # 型チェック
+bun run --bun test        # テスト
 ```
 
 個別パッケージで実行:
 ```bash
-bun run --filter frontend dev
-bun run --filter backend dev
+bun run --bun --filter frontend dev
+bun run --bun --filter backend dev
 ```
 
 ## Development Workflow
 
 **重要**: コードを実装した後は、必ず以下のコマンドを順番に実行してエラーがないことを確認する：
 
-1. `bun type-check` - 型エラーがないことを確認
-2. `bun format` - コードをフォーマット
-3. `bun lint` - lint エラーがないことを確認
+1. `bun run --bun type-check` - 型エラーがないことを確認
+2. `bun run --bun format` - コードをフォーマット
+3. `bun run --bun lint` - lint エラーがないことを確認
 
 すべてのコマンドが成功するまで、実装は完了とみなさない。
 
@@ -110,15 +110,3 @@ bun run --filter backend dev
 1. 将来同じような実装をする際に参照する価値があるか
 2. 他の開発者（または将来の自分）が同じ問題に直面する可能性があるか
 3. 情報がコード内のコメントだけでは不十分か
-
-## Testing
-
-Use `vitest` to run tests.
-
-```ts
-import { test, expect } from "vitest";
-
-test("example test", () => {
-  expect(1).toBe(1);
-});
-```

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ bun install
 開発サーバーを起動（frontend: 3000, backend: 8787）:
 
 ```bash
-bun dev
+bun run --bun dev
 ```
 
 ### コマンド一覧
 
 ```bash
-bun lint        # リンティング
-bun format      # フォーマット
-bun type-check  # 型チェック
-bun test        # テスト
-bun build       # ビルド
-bun deploy      # Cloudflare Workersにデプロイ
+bun run --bun lint        # リンティング
+bun run --bun format      # フォーマット
+bun run --bun type-check  # 型チェック
+bun run --bun test        # テスト
+bun run --bun build       # ビルド
+bun run --bun deploy      # Cloudflare Workersにデプロイ
 ```
 
 ## ライセンス

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "main": "./src/index.ts",
   "scripts": {
-    "lint": "bunx --bun oxlint && bunx --bun oxfmt --check ./src",
-    "format": "bunx --bun oxlint --fix && bunx --bun oxfmt --write ./src",
-    "type-check": "bunx --bun oxlint --type-aware --type-check",
+    "lint": "oxlint && oxfmt --check ./src",
+    "format": "oxlint --fix && oxfmt --write ./src",
+    "type-check": "oxlint --type-aware --type-check",
     "dev": "bun --hot --port 8787 ./src/index.ts",
-    "preview": "bunx --bun wrangler dev --port 8787",
-    "deploy": "bunx --bun wrangler deploy"
+    "preview": "wrangler dev --port 8787",
+    "deploy": "wrangler deploy"
   },
   "dependencies": {
     "@discordjs/rest": "2.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,13 +3,13 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "lint": "bunx --bun oxlint && bunx --bun oxfmt --check ./src ./test",
-    "format": "bunx --bun oxlint --fix && bunx --bun oxfmt --write ./src ./test",
-    "type-check": "bunx --bun oxlint --type-aware --type-check",
-    "dev": "bunx --bun vite --port 3000",
-    "build": "bunx --bun vite build && tsc",
-    "preview": "bunx --bun vite preview",
-    "deploy": "bun run build && wrangler deploy",
+    "lint": "oxlint && oxfmt --check ./src ./test",
+    "format": "oxlint --fix && oxfmt --write ./src ./test",
+    "type-check": "oxlint --type-aware --type-check",
+    "dev": "vite --port 3000",
+    "build": "vite build && tsc",
+    "preview": "vite preview",
+    "deploy": "bun run --bun build && wrangler deploy",
     "test": "bun test"
   },
   "dependencies": {


### PR DESCRIPTION
## 概要
Bunコマンドの実行方法を統一し、コマンド実行の一貫性を向上させる。

## 変更内容
- `bun xxx` → `bun run --bun xxx` 形式に統一（CLAUDE.md, README.md）
- package.json内のscriptsから不要な `bunx --bun` プレフィックスを削除
- scriptsから呼び出される場合は既にBun環境なので `bunx --bun` は不要

## 影響範囲
- ドキュメント: CLAUDE.md, README.md
- 設定ファイル: backend/package.json, frontend/package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)