### PR TITLE
fix: add guildId to channel permission API for everyone role deny

### DIFF
--- a/backend/src/discord.ts
+++ b/backend/src/discord.ts
@@ -163,6 +163,11 @@ export async function createChannel(token: string, data: CreateChannelData) {
       name: data.name,
       parent_id: data.parentCategoryId,
       permission_overwrites: [
+        {
+          id: data.guildId,
+          type: OverwriteType.Role,
+          deny: allPermission.toString(),
+        },
         ...data.writerRoleIds.map((r) => ({
           id: r,
           type: OverwriteType.Role,
@@ -187,6 +192,11 @@ export async function changeChannelPermissions(token: string, data: ChangeChanne
   await rest.patch(Routes.channel(data.channelId), {
     body: {
       permission_overwrites: [
+        {
+          id: data.guildId,
+          type: OverwriteType.Role,
+          deny: allPermission.toString(),
+        },
         ...data.writerRoleIds.map((r) => ({
           id: r,
           type: OverwriteType.Role,

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -27,6 +27,7 @@ export const createChannelSchema = z.object({
 });
 
 export const changeChannelPermissionsSchema = z.object({
+  guildId: z.string().nonempty().trim(),
   channelId: z.string().nonempty().trim(),
   writerRoleIds: z.array(z.string().nonempty().trim()),
   readerRoleIds: z.array(z.string().nonempty().trim()),

--- a/frontend/src/components/Node/nodes/ChangeChannelPermissionNode.tsx
+++ b/frontend/src/components/Node/nodes/ChangeChannelPermissionNode.tsx
@@ -89,7 +89,7 @@ export const ChangeChannelPermissionNode = ({
       return;
     }
 
-    const { bot } = executionContext;
+    const { guildId, bot } = executionContext;
 
     if (data.channelName.trim() === "") {
       addToast({ message: "チャンネル名を入力してください", status: "warning" });
@@ -145,6 +145,7 @@ export const ChangeChannelPermissionNode = ({
 
     try {
       await client.changeChannelPermissions({
+        guildId,
         channelId: channel.id,
         writerRoleIds,
         readerRoleIds,


### PR DESCRIPTION
## Summary

- バックエンドの `changeChannelPermissions` API に `guildId` パラメータを追加
- チャンネル権限変更時に everyone ロール（@everyone）の全権限を拒否するよう修正
- フロントエンドの `ChangeChannelPermissionNode` で API 呼び出し時に `guildId` を渡すよう修正

## Changes

### Backend (`backend/src/discord.ts`, `backend/src/schemas.ts`)
- `changeChannelPermissionsSchema` に `guildId` を必須パラメータとして追加
- `changeChannelPermissions` 関数で everyone ロールの permission_overwrites を追加（全権限を deny）
- `createChannel` 関数でも同様に everyone ロールの権限を全拒否

### Frontend (`frontend/src/components/Node/nodes/ChangeChannelPermissionNode.tsx`)
- `executionContext` から `guildId` を取得
- `changeChannelPermissions` API 呼び出し時に `guildId` を含める

## Test plan

- [x] 型チェック: `bun run --bun type-check` ✅
- [x] フォーマット: `bun run --bun format` ✅
- [x] Lint: `bun run --bun lint` ✅
- [x] 手動テスト: ChangeChannelPermissionNode でチャンネル権限を変更し、everyone ロールが正しく拒否されることを確認

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)