### PR TITLE
feat: display NodeFooter in both edit and execute modes

### DIFF
--- a/frontend/src/components/Node/nodes/AddRoleToRoleMembersNode.tsx
+++ b/frontend/src/components/Node/nodes/AddRoleToRoleMembersNode.tsx
@@ -153,19 +153,17 @@ export const AddRoleToRoleMembersNode = ({
           />
         </div>
       </BaseNodeContent>
-      {isExecuteMode && (
-        <BaseNodeFooter>
-          <button
-            type="button"
-            className="nodrag btn btn-primary"
-            onClick={handleExecute}
-            disabled={isLoading || !!data.executedAt}
-          >
-            {isLoading && <span className="loading loading-spinner loading-sm"></span>}
-            実行
-          </button>
-        </BaseNodeFooter>
-      )}
+      <BaseNodeFooter>
+        <button
+          type="button"
+          className="nodrag btn btn-primary"
+          onClick={handleExecute}
+          disabled={!isExecuteMode || isLoading || !!data.executedAt}
+        >
+          {isLoading && <span className="loading loading-spinner loading-sm"></span>}
+          実行
+        </button>
+      </BaseNodeFooter>
       <BaseHandle id="target-1" type="target" position={Position.Top} />
       <BaseHandle id="source-1" type="source" position={Position.Bottom} />
     </BaseNode>

--- a/frontend/src/components/Node/nodes/ChangeChannelPermissionNode.tsx
+++ b/frontend/src/components/Node/nodes/ChangeChannelPermissionNode.tsx
@@ -279,19 +279,17 @@ export const ChangeChannelPermissionNode = ({
           )}
         </div>
       </BaseNodeContent>
-      {isExecuteMode && (
-        <BaseNodeFooter>
-          <button
-            type="button"
-            className="nodrag btn btn-primary"
-            onClick={handleChangePermissions}
-            disabled={isLoading || !!data.executedAt}
-          >
-            {isLoading && <span className="loading loading-spinner loading-sm"></span>}
-            実行
-          </button>
-        </BaseNodeFooter>
-      )}
+      <BaseNodeFooter>
+        <button
+          type="button"
+          className="nodrag btn btn-primary"
+          onClick={handleChangePermissions}
+          disabled={!isExecuteMode || isLoading || !!data.executedAt}
+        >
+          {isLoading && <span className="loading loading-spinner loading-sm"></span>}
+          実行
+        </button>
+      </BaseNodeFooter>
       <BaseHandle id="target-1" type="target" position={Position.Top} />
       <BaseHandle id="source-1" type="source" position={Position.Bottom} />
     </BaseNode>

--- a/frontend/src/components/Node/nodes/CreateCategoryNode.tsx
+++ b/frontend/src/components/Node/nodes/CreateCategoryNode.tsx
@@ -124,19 +124,17 @@ export const CreateCategoryNode = ({
           disabled={isExecuteMode || isLoading || isExecuted}
         />
       </BaseNodeContent>
-      {isExecuteMode && (
-        <BaseNodeFooter>
-          <button
-            type="button"
-            className="nodrag btn btn-primary"
-            onClick={handleCreateCategory}
-            disabled={isLoading || !!data.executedAt}
-          >
-            {isLoading && <span className="loading loading-spinner loading-sm"></span>}
-            作成
-          </button>
-        </BaseNodeFooter>
-      )}
+      <BaseNodeFooter>
+        <button
+          type="button"
+          className="nodrag btn btn-primary"
+          onClick={handleCreateCategory}
+          disabled={!isExecuteMode || isLoading || !!data.executedAt}
+        >
+          {isLoading && <span className="loading loading-spinner loading-sm"></span>}
+          作成
+        </button>
+      </BaseNodeFooter>
       <BaseHandle id="target-1" type="target" position={Position.Top} />
       <BaseHandle id="source-1" type="source" position={Position.Bottom} />
     </BaseNode>

--- a/frontend/src/components/Node/nodes/CreateChannelNode.tsx
+++ b/frontend/src/components/Node/nodes/CreateChannelNode.tsx
@@ -364,19 +364,17 @@ export const CreateChannelNode = ({
           </div>
         )}
       </BaseNodeContent>
-      {isExecuteMode && (
-        <BaseNodeFooter>
-          <button
-            type="button"
-            className="nodrag btn btn-primary"
-            onClick={handleCreateChannels}
-            disabled={isLoading || !!data.executedAt}
-          >
-            {isLoading && <span className="loading loading-spinner loading-sm"></span>}
-            作成
-          </button>
-        </BaseNodeFooter>
-      )}
+      <BaseNodeFooter>
+        <button
+          type="button"
+          className="nodrag btn btn-primary"
+          onClick={handleCreateChannels}
+          disabled={!isExecuteMode || isLoading || !!data.executedAt}
+        >
+          {isLoading && <span className="loading loading-spinner loading-sm"></span>}
+          作成
+        </button>
+      </BaseNodeFooter>
       <BaseHandle id="target-1" type="target" position={Position.Top} />
       <BaseHandle id="source-1" type="source" position={Position.Bottom} />
     </BaseNode>

--- a/frontend/src/components/Node/nodes/CreateRoleNode.tsx
+++ b/frontend/src/components/Node/nodes/CreateRoleNode.tsx
@@ -156,19 +156,17 @@ export const CreateRoleNode = ({
           </div>
         )}
       </BaseNodeContent>
-      {isExecuteMode && (
-        <BaseNodeFooter>
-          <button
-            type="button"
-            className="nodrag btn btn-primary"
-            onClick={handleCreateRoles}
-            disabled={isLoading || !!data.executedAt}
-          >
-            {isLoading && <span className="loading loading-spinner loading-sm"></span>}
-            作成
-          </button>
-        </BaseNodeFooter>
-      )}
+      <BaseNodeFooter>
+        <button
+          type="button"
+          className="nodrag btn btn-primary"
+          onClick={handleCreateRoles}
+          disabled={!isExecuteMode || isLoading || !!data.executedAt}
+        >
+          {isLoading && <span className="loading loading-spinner loading-sm"></span>}
+          作成
+        </button>
+      </BaseNodeFooter>
       <BaseHandle id="target-1" type="target" position={Position.Top} />
       <BaseHandle id="source-1" type="source" position={Position.Bottom} />
     </BaseNode>

--- a/frontend/src/components/Node/nodes/DeleteCategoryNode.tsx
+++ b/frontend/src/components/Node/nodes/DeleteCategoryNode.tsx
@@ -157,19 +157,17 @@ export const DeleteCategoryNode = ({
           </div>
         )}
       </BaseNodeContent>
-      {isExecuteMode && (
-        <BaseNodeFooter>
-          <button
-            type="button"
-            className="btn btn-error"
-            onClick={handleDelete}
-            disabled={isLoading || !!data.executedAt}
-          >
-            {isLoading && <span className="loading loading-spinner loading-sm"></span>}
-            削除
-          </button>
-        </BaseNodeFooter>
-      )}
+      <BaseNodeFooter>
+        <button
+          type="button"
+          className="btn btn-error"
+          onClick={handleDelete}
+          disabled={!isExecuteMode || isLoading || !!data.executedAt}
+        >
+          {isLoading && <span className="loading loading-spinner loading-sm"></span>}
+          削除
+        </button>
+      </BaseNodeFooter>
       <BaseHandle id="target-1" type="target" position={Position.Top} />
       <BaseHandle id="source-1" type="source" position={Position.Bottom} />
     </BaseNode>

--- a/frontend/src/components/Node/nodes/DeleteChannelNode.tsx
+++ b/frontend/src/components/Node/nodes/DeleteChannelNode.tsx
@@ -183,19 +183,17 @@ export const DeleteChannelNode = ({
           </div>
         )}
       </BaseNodeContent>
-      {isExecuteMode && (
-        <BaseNodeFooter>
-          <button
-            type="button"
-            className="nodrag btn btn-error"
-            onClick={handleDeleteChannels}
-            disabled={isLoading || !!data.executedAt}
-          >
-            {isLoading && <span className="loading loading-spinner loading-sm"></span>}
-            削除
-          </button>
-        </BaseNodeFooter>
-      )}
+      <BaseNodeFooter>
+        <button
+          type="button"
+          className="nodrag btn btn-error"
+          onClick={handleDeleteChannels}
+          disabled={!isExecuteMode || isLoading || !!data.executedAt}
+        >
+          {isLoading && <span className="loading loading-spinner loading-sm"></span>}
+          削除
+        </button>
+      </BaseNodeFooter>
       <BaseHandle id="target-1" type="target" position={Position.Top} />
       <BaseHandle id="source-1" type="source" position={Position.Bottom} />
     </BaseNode>

--- a/frontend/src/components/Node/nodes/DeleteRoleNode.tsx
+++ b/frontend/src/components/Node/nodes/DeleteRoleNode.tsx
@@ -217,19 +217,17 @@ export const DeleteRoleNode = ({
           </div>
         )}
       </BaseNodeContent>
-      {isExecuteMode && (
-        <BaseNodeFooter>
-          <button
-            type="button"
-            className="nodrag btn btn-error"
-            onClick={handleDeleteRoles}
-            disabled={isLoading || !!data.executedAt}
-          >
-            {isLoading && <span className="loading loading-spinner loading-sm"></span>}
-            削除
-          </button>
-        </BaseNodeFooter>
-      )}
+      <BaseNodeFooter>
+        <button
+          type="button"
+          className="nodrag btn btn-error"
+          onClick={handleDeleteRoles}
+          disabled={!isExecuteMode || isLoading || !!data.executedAt}
+        >
+          {isLoading && <span className="loading loading-spinner loading-sm"></span>}
+          削除
+        </button>
+      </BaseNodeFooter>
       <BaseHandle id="target-1" type="target" position={Position.Top} />
       <BaseHandle id="source-1" type="source" position={Position.Bottom} />
     </BaseNode>

--- a/frontend/src/components/Node/nodes/RecordCombinationNode.tsx
+++ b/frontend/src/components/Node/nodes/RecordCombinationNode.tsx
@@ -656,11 +656,9 @@ export const RecordCombinationNode = ({
         )}
       </BaseNodeContent>
 
-      {isExecuteMode && (
-        <BaseNodeFooter>
-          <div className="text-xs text-base-content/50">{data.recordedPairs.length}件記録済み</div>
-        </BaseNodeFooter>
-      )}
+      <BaseNodeFooter>
+        <div className="text-xs text-base-content/50">{data.recordedPairs.length}件記録済み</div>
+      </BaseNodeFooter>
     </BaseNode>
   );
 };

--- a/frontend/src/components/Node/nodes/SelectBranchNode.tsx
+++ b/frontend/src/components/Node/nodes/SelectBranchNode.tsx
@@ -332,19 +332,17 @@ export const SelectBranchNode = ({
         )}
       </BaseNodeContent>
 
-      {isExecuteMode && !isExecuted && (
-        <BaseNodeFooter>
-          <button
-            type="button"
-            className="nodrag btn btn-primary w-full"
-            onClick={handleExecute}
-            disabled={isLoading || !selectedOption}
-          >
-            {isLoading && <span className="loading loading-spinner loading-sm" />}
-            確定する
-          </button>
-        </BaseNodeFooter>
-      )}
+      <BaseNodeFooter>
+        <button
+          type="button"
+          className="nodrag btn btn-primary w-full"
+          onClick={handleExecute}
+          disabled={!isExecuteMode || isExecuted || isLoading || !selectedOption}
+        >
+          {isLoading && <span className="loading loading-spinner loading-sm" />}
+          確定する
+        </button>
+      </BaseNodeFooter>
 
       <BaseHandle id="target-1" type="target" position={Position.Top} />
       <BaseHandle id="source-1" type="source" position={Position.Bottom} />

--- a/frontend/src/components/Node/nodes/SendMessageNode.tsx
+++ b/frontend/src/components/Node/nodes/SendMessageNode.tsx
@@ -571,19 +571,17 @@ export const SendMessageNode = ({
         </div>
       </BaseNodeContent>
 
-      {isExecuteMode && (
-        <BaseNodeFooter>
-          <button
-            type="button"
-            className="nodrag btn btn-primary"
-            onClick={handleSendMessage}
-            disabled={isLoading || !!data.executedAt}
-          >
-            {isLoading && <span className="loading loading-spinner loading-sm"></span>}
-            送信
-          </button>
-        </BaseNodeFooter>
-      )}
+      <BaseNodeFooter>
+        <button
+          type="button"
+          className="nodrag btn btn-primary"
+          onClick={handleSendMessage}
+          disabled={!isExecuteMode || isLoading || !!data.executedAt}
+        >
+          {isLoading && <span className="loading loading-spinner loading-sm"></span>}
+          送信
+        </button>
+      </BaseNodeFooter>
 
       <BaseHandle id="target-1" type="target" position={Position.Top} />
       <BaseHandle id="source-1" type="source" position={Position.Bottom} />

--- a/frontend/src/components/Node/nodes/SetGameFlagNode.tsx
+++ b/frontend/src/components/Node/nodes/SetGameFlagNode.tsx
@@ -130,19 +130,17 @@ export const SetGameFlagNode = ({
           />
         </label>
       </BaseNodeContent>
-      {isExecuteMode && (
-        <BaseNodeFooter>
-          <button
-            type="button"
-            className="nodrag btn btn-primary"
-            onClick={handleSetFlag}
-            disabled={isLoading || isExecuted}
-          >
-            {isLoading && <span className="loading loading-spinner loading-sm"></span>}
-            設定
-          </button>
-        </BaseNodeFooter>
-      )}
+      <BaseNodeFooter>
+        <button
+          type="button"
+          className="nodrag btn btn-primary"
+          onClick={handleSetFlag}
+          disabled={!isExecuteMode || isLoading || isExecuted}
+        >
+          {isLoading && <span className="loading loading-spinner loading-sm"></span>}
+          設定
+        </button>
+      </BaseNodeFooter>
       <BaseHandle id="target-1" type="target" position={Position.Top} />
       <BaseHandle id="source-1" type="source" position={Position.Bottom} />
     </BaseNode>

--- a/frontend/src/components/Node/nodes/ShuffleAssignNode.tsx
+++ b/frontend/src/components/Node/nodes/ShuffleAssignNode.tsx
@@ -317,19 +317,17 @@ export const ShuffleAssignNode = ({
           </div>
         )}
       </BaseNodeContent>
-      {isExecuteMode && (
-        <BaseNodeFooter>
-          <button
-            type="button"
-            className="nodrag btn btn-primary"
-            onClick={handleShuffle}
-            disabled={isLoading || isExecuted}
-          >
-            {isLoading && <span className="loading loading-spinner loading-sm"></span>}
-            シャッフル実行
-          </button>
-        </BaseNodeFooter>
-      )}
+      <BaseNodeFooter>
+        <button
+          type="button"
+          className="nodrag btn btn-primary"
+          onClick={handleShuffle}
+          disabled={!isExecuteMode || isLoading || isExecuted}
+        >
+          {isLoading && <span className="loading loading-spinner loading-sm"></span>}
+          シャッフル実行
+        </button>
+      </BaseNodeFooter>
       <BaseHandle id="target-1" type="target" position={Position.Top} />
       <BaseHandle id="source-1" type="source" position={Position.Bottom} />
     </BaseNode>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,11 +5,9 @@ import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
 import { URL, fileURLToPath } from "node:url";
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     devtools(),
-    // @ts-ignore -- tailwindcss has no types
     tailwindcss(),
     tanstackRouter({
       target: "react",


### PR DESCRIPTION
## Summary
- Edit modeでもNodeFooterを表示するように変更
- Edit mode時はボタンを無効化（押せない状態）
- Execute mode時は従来通り動作

## Changes
- 13個のノードコンポーネントで`{isExecuteMode && <BaseNodeFooter>...}`の条件を削除
- ボタンの`disabled`属性に`!isExecuteMode`を追加
- vite.config.tsの不要なコメントを削除

## Test plan
- [ ] Edit modeでNodeFooterが表示されることを確認
- [ ] Edit modeでボタンが無効化されていることを確認  
- [ ] Execute modeで正常にボタンが動作することを確認
- [ ] 型チェック、lint、formatが通ることを確認（✅済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)