### PR TITLE
node-creatorスキルの誤りを修正し、新しいパターンを追加

### DIFF
--- a/.claude/skills/node-creator/SKILL.md
+++ b/.claude/skills/node-creator/SKILL.md
@@ -5,7 +5,7 @@ description: Create new Node types for the React Flow based workflow editor. Use
 
 # Node Creator
 
-Create new Node components for the @xyflow/react based workflow editor. Each node represents a Discord operation (create/delete roles, categories, channels, etc.).
+Create new Node components for the @xyflow/react based workflow editor. Each node represents a Discord operation (create/delete roles, categories, channels, send messages, etc.).
 
 ## Implementation Checklist
 
@@ -15,8 +15,9 @@ When creating a new node type `{NodeName}Node`:
 2. Add width to `frontend/src/components/Node/base/base-schema.ts`
 3. Register in `frontend/src/components/Node/base/node-wrapper.tsx`
 4. Export from `frontend/src/components/Node/nodes/index.ts`
-5. Add types/data to `frontend/src/stores/templateEditorStore.ts`
-6. Add UI option in `frontend/src/components/TemplateEditor.tsx`
+5. Re-export from `frontend/src/components/Node/index.ts`
+6. Add types/data to `frontend/src/stores/templateEditorStore.ts`
+7. Add UI option in `frontend/src/components/TemplateEditor.tsx`
 
 ## Node Component Template
 
@@ -25,8 +26,8 @@ import { Position, type Node, type NodeProps } from "@xyflow/react";
 import { useState } from "react";
 import z from "zod";
 
-import { db } from "@/db";
 import { ApiClient } from "@/api";
+import { db } from "@/db";
 import { useTemplateEditorStore } from "@/stores/templateEditorStore";
 import { useToast } from "@/toast/ToastProvider";
 
@@ -39,14 +40,14 @@ import {
   BaseNodeHeaderTitle,
   cn,
   BaseNodeDataSchema,
+  NODE_CONTENT_HEIGHTS,
   NODE_TYPE_WIDTHS,
 } from "../base";
 import { useNodeExecutionOptional } from "../contexts";
 
 // 1. Define schema extending BaseNodeDataSchema
 export const DataSchema = BaseNodeDataSchema.extend({
-  // Add node-specific fields here
-  fieldName: z.string().trim(),
+  fieldName: z.string().trim().default(""),
 });
 type {NodeName}NodeData = Node<z.infer<typeof DataSchema>, "{NodeName}">;
 
@@ -75,7 +76,6 @@ export const {NodeName}Node = ({
     }
 
     const { guildId, sessionId, bot } = executionContext;
-    // Validate input
     if (data.fieldName.trim() === "") {
       addToast({ message: "入力してください", status: "warning" });
       return;
@@ -99,8 +99,12 @@ export const {NodeName}Node = ({
   };
 
   const isExecuteMode = mode === "execute";
+  const isExecuted = !!data.executedAt;
 
   // 5. Render with BaseNode components
+  //    - Add "nodrag" class to ALL interactive elements (inputs, buttons, textareas)
+  //    - Disable inputs when: isExecuteMode || isLoading || isExecuted
+  //    - Disable action button when: !isExecuteMode || isLoading || isExecuted
   return (
     <BaseNode
       width={NODE_TYPE_WIDTHS.{NodeName}}
@@ -109,35 +113,35 @@ export const {NodeName}Node = ({
       <BaseNodeHeader>
         <BaseNodeHeaderTitle>ノードタイトル</BaseNodeHeaderTitle>
       </BaseNodeHeader>
-      <BaseNodeContent>
+      <BaseNodeContent maxHeight={NODE_CONTENT_HEIGHTS.md}>
         <input
           type="text"
-          className="input input-bordered w-full"
+          className="nodrag input input-bordered w-full"
           value={data.fieldName}
           onChange={(evt) => handleFieldChange(evt.target.value)}
           placeholder="入力"
-          disabled={isLoading}
+          disabled={isExecuteMode || isLoading || isExecuted}
         />
       </BaseNodeContent>
-      {isExecuteMode && (
-        <BaseNodeFooter>
-          <button
-            type="button"
-            className="btn btn-primary"
-            onClick={handleExecute}
-            disabled={isLoading || !!data.executedAt}
-          >
-            {isLoading && <span className="loading loading-spinner loading-sm"></span>}
-            実行
-          </button>
-        </BaseNodeFooter>
-      )}
+      <BaseNodeFooter>
+        <button
+          type="button"
+          className="nodrag btn btn-primary"
+          onClick={handleExecute}
+          disabled={!isExecuteMode || isLoading || isExecuted}
+        >
+          {isLoading && <span className="loading loading-spinner loading-sm"></span>}
+          実行
+        </button>
+      </BaseNodeFooter>
       <BaseHandle id="target-1" type="target" position={Position.Left} />
       <BaseHandle id="source-1" type="source" position={Position.Right} />
     </BaseNode>
   );
 };
 ```
+
+> **重要**: `nodrag` クラスはドラッグ誤作動を防ぐため、すべてのインタラクティブ要素（`input`, `button`, `textarea`, `select` 等）に必須。
 
 ## Registration Steps
 
@@ -153,14 +157,12 @@ export const NODE_TYPE_WIDTHS: Record<string, NodeWidth> = {
 ### node-wrapper.tsx
 
 ```ts
-// frontend/src/components/Node/base/node-wrapper.tsx
-import { {NodeName}Node } from "../nodes/{NodeName}Node";
+import { {NodeName}Node } from "../nodes";  // nodes/index.ts 経由
 
 export function createNodeTypes(mode: "edit" | "execute" = "edit"): NodeTypes {
   const {NodeName}WithMode: ComponentType<NodeProps<any>> = (props) => (
     <{NodeName}Node {...props} mode={mode} />
   );
-  // ...
   return {
     // existing...
     {NodeName}: {NodeName}WithMode,
@@ -171,8 +173,16 @@ export function createNodeTypes(mode: "edit" | "execute" = "edit"): NodeTypes {
 ### nodes/index.ts
 
 ```ts
-// frontend/src/components/Node/nodes/index.ts
 export { {NodeName}Node, DataSchema as {NodeName}DataSchema } from "./{NodeName}Node";
+```
+
+### Node/index.ts
+
+```ts
+export {
+  // existing...
+  {NodeName}DataSchema,
+} from "./nodes";
 ```
 
 ### templateEditorStore.ts
@@ -186,49 +196,33 @@ export type FlowNode =
   // existing...
   | Node<{NodeName}NodeData, "{NodeName}">;
 
-// In addNode function:
-addNode: (type, position) => {
-  // ...
-  if (type === "{NodeName}") {
-    newNode = {
-      id,
-      type,
-      position,
-      data: { fieldName: "" }, // default data
-    };
-  }
-  // ...
-}
+// updateNodeData の data 引数 union に追加:
+data: Partial<... | {NodeName}NodeData>
 
-// Update type signatures:
-updateNodeData: (nodeId: string, data: Partial<... | {NodeName}NodeData>) => void;
+// addNode の type union に追加:
 addNode: (type: "..." | "{NodeName}", position: { x: number; y: number }) => void;
+
+// addNode 実装に分岐追加:
+} else if (type === "{NodeName}") {
+  newNode = { id, type, position, data: { fieldName: "" } };
+}
 ```
 
 ### TemplateEditor.tsx
 
-Add to modal and handleAddNode:
+`NODE_CATEGORIES` 配列の適切なカテゴリに追加するだけ:
 
 ```tsx
-// In handleAddNode:
-if (selectedNodeType === "{NodeName}" || ...) {
-  addNode(selectedNodeType, position);
-}
-
-// In modal radio buttons:
-<label className="card cursor-pointer">
-  <div className="card-body">
-    <input
-      type="radio"
-      name="nodeType"
-      value="{NodeName}"
-      checked={selectedNodeType === "{NodeName}"}
-      onChange={(e) => setSelectedNodeType(e.target.value)}
-      className="radio"
-    />
-    <span className="ml-2">ノードの説明</span>
-  </div>
-</label>
+const NODE_CATEGORIES = [
+  // ...
+  {
+    category: "カテゴリ名",
+    nodes: [
+      // existing...
+      { type: "{NodeName}", label: "ノードの説明" },
+    ],
+  },
+] as const;
 ```
 
 ## Node Patterns
@@ -238,6 +232,8 @@ See [references/patterns.md](references/patterns.md) for common implementation p
 - Multiple value list (like CreateRoleNode)
 - Selection from existing data (like DeleteRoleNode)
 - Progress tracking for batch operations
+- ResourceSelector (channel/role picker from preceding nodes)
+- Message blocks with file attachment
 
 ## Execution Context
 
@@ -247,6 +243,7 @@ Nodes receive execution context via `useNodeExecutionOptional()`:
 interface NodeExecutionContextValue {
   guildId: string;      // Discord guild ID
   sessionId: number;    // Session ID for DB scoping
+  sessionName: string;  // Session name (for DynamicValue resolution)
   bot: DiscordBotData;  // Bot token and profile
 }
 ```
@@ -260,3 +257,4 @@ Available in `@/api`:
 - `createChannel({ guildId, parentCategoryId, name, type, writerRoleIds, readerRoleIds })`
 - `deleteChannel({ guildId, channelId })`
 - `changeChannelPermissions({ channelId, writerRoleIds, readerRoleIds })`
+- `sendMessage({ channelId, content, files? })`

--- a/.claude/skills/node-creator/references/patterns.md
+++ b/.claude/skills/node-creator/references/patterns.md
@@ -6,18 +6,18 @@ Simple node with one input field. Example: CreateCategoryNode
 
 ```tsx
 export const DataSchema = BaseNodeDataSchema.extend({
-  categoryName: z.string().trim(),
+  categoryName: z.string().trim().default(""),
 });
 
 // In component:
 <BaseNodeContent>
   <input
     type="text"
-    className="input input-bordered w-full"
+    className="nodrag input input-bordered w-full"
     value={data.categoryName}
     onChange={(evt) => handleChange(evt.target.value)}
     placeholder="カテゴリ名を入力"
-    disabled={isLoading}
+    disabled={isExecuteMode || isLoading || isExecuted}
   />
 </BaseNodeContent>
 ```
@@ -51,7 +51,7 @@ Node with dynamic list of inputs. Example: CreateRoleNode
 
 ```tsx
 export const DataSchema = BaseNodeDataSchema.extend({
-  roles: z.array(z.string().nonempty().trim()),
+  roles: z.array(z.string().trim()).min(1).default([""]),
 });
 
 // Handlers:
@@ -75,17 +75,18 @@ const handleRemoveItem = (index: number) => {
     <div key={`${id}-role-${index}`} className="flex gap-2 items-center mb-2">
       <input
         type="text"
-        className="input input-bordered w-full"
+        className="nodrag input input-bordered w-full"
         value={role}
         onChange={(evt) => handleItemChange(index, evt.target.value)}
         placeholder="ロール名を入力"
-        disabled={isLoading}
+        disabled={isExecuteMode || isLoading || isExecuted}
       />
-      {!isExecuteMode && (
+      {!isExecuteMode && data.roles.length > 1 && (
         <button
           type="button"
-          className="btn btn-ghost btn-sm"
+          className="nodrag btn btn-ghost btn-sm"
           onClick={() => handleRemoveItem(index)}
+          disabled={isLoading || isExecuted}
         >
           削除
         </button>
@@ -93,8 +94,13 @@ const handleRemoveItem = (index: number) => {
     </div>
   ))}
   {!isExecuteMode && (
-    <button type="button" className="btn btn-ghost btn-sm mt-2" onClick={handleAddItem}>
-      ロールを追加
+    <button
+      type="button"
+      className="nodrag btn btn-ghost btn-sm mt-2"
+      onClick={handleAddItem}
+      disabled={isLoading || isExecuted}
+    >
+      + 追加
     </button>
   )}
 </BaseNodeContent>
@@ -106,8 +112,8 @@ Node that selects from DB data. Example: DeleteRoleNode
 
 ```tsx
 export const DataSchema = BaseNodeDataSchema.extend({
-  deleteAll: z.boolean(),
-  selectedRoleIds: z.array(z.string()),
+  deleteAll: z.boolean().default(false),
+  selectedRoleIds: z.array(z.string()).default([]),
 });
 
 // Load data from DB:
@@ -122,28 +128,16 @@ useEffect(() => {
   }
 }, [executionContext]);
 
-// Handlers:
-const handleDeleteAllChange = (checked: boolean) => {
-  updateNodeData(id, { deleteAll: checked, selectedRoleIds: [] });
-};
-
-const handleItemToggle = (itemId: string) => {
-  const newSelected = data.selectedRoleIds.includes(itemId)
-    ? data.selectedRoleIds.filter((id) => id !== itemId)
-    : [...data.selectedRoleIds, itemId];
-  updateNodeData(id, { selectedRoleIds: newSelected });
-};
-
 // In component:
 <BaseNodeContent>
   <div className="form-control mb-2">
     <label className="label cursor-pointer justify-start gap-2">
       <input
         type="checkbox"
-        className="checkbox"
+        className="nodrag checkbox"
         checked={data.deleteAll}
-        onChange={(e) => handleDeleteAllChange(e.target.checked)}
-        disabled={isLoading}
+        onChange={(e) => updateNodeData(id, { deleteAll: e.target.checked })}
+        disabled={isExecuteMode || isLoading || isExecuted}
       />
       <span className="label-text">すべて削除</span>
     </label>
@@ -155,10 +149,15 @@ const handleItemToggle = (itemId: string) => {
         <label key={role.id} className="label cursor-pointer justify-start gap-2 py-1">
           <input
             type="checkbox"
-            className="checkbox checkbox-sm"
+            className="nodrag checkbox checkbox-sm"
             checked={data.selectedRoleIds.includes(role.id)}
-            onChange={() => handleItemToggle(role.id)}
-            disabled={isLoading}
+            onChange={() => {
+              const newSelected = data.selectedRoleIds.includes(role.id)
+                ? data.selectedRoleIds.filter((id) => id !== role.id)
+                : [...data.selectedRoleIds, role.id];
+              updateNodeData(id, { selectedRoleIds: newSelected });
+            }}
+            disabled={isExecuteMode || isLoading || isExecuted}
           />
           <span className="label-text">{role.name}</span>
         </label>
@@ -225,17 +224,95 @@ const handleExecute = async () => {
 )}
 ```
 
-## Button Styling
+## Pattern 5: ResourceSelector (Channel/Role Picker)
 
-- Primary action (create): `btn btn-primary`
-- Destructive action (delete): `btn btn-error`
-- Neutral action: `btn btn-ghost`
+`ResourceSelector` は先行ノードが作成したチャンネルやロールを候補に表示するセレクタ。
+Import: `import { ResourceSelector } from "../utils";`
 
-## Node Width Guidelines
+```tsx
+export const DataSchema = BaseNodeDataSchema.extend({
+  channelName: z.string().trim().default(""),
+});
 
-| Width | Use Case |
-|-------|----------|
-| sm (192) | Single short input |
-| md (256) | Basic size, Simple input(s) with label |
-| lg (480) | Complex forms |
-| xl (640) | Complex layout |
+// In component:
+<BaseNodeContent>
+  <label className="text-xs font-semibold mb-1 block">送信先チャンネル</label>
+  <ResourceSelector
+    nodeId={id}
+    resourceType="channel"   // "channel" | "role"
+    value={data.channelName}
+    onChange={(newName) => updateNodeData(id, { channelName: newName })}
+    placeholder="チャンネル名"
+    disabled={isExecuteMode || isLoading || isExecuted}
+    channelTypeFilter="text"  // "text" | "voice" (channelのみ)
+  />
+</BaseNodeContent>
+```
+
+実行時のチャンネル解決:
+```tsx
+const [channels, setChannels] = useState<ChannelData[]>([]);
+
+useEffect(() => {
+  if (executionContext) {
+    void db.Channel.where("sessionId")
+      .equals(executionContext.sessionId)
+      .toArray()
+      .then(setChannels);
+  }
+}, [executionContext]);
+
+// In handleExecute:
+const channel = channels.find((c) => c.name === data.channelName.trim());
+if (!channel) {
+  addToast({ message: `チャンネルが見つかりません: ${data.channelName}`, status: "error" });
+  return;
+}
+await client.sendMessage({ channelId: channel.id, content: "..." });
+```
+
+## Pattern 6: Message Blocks with File Attachment
+
+複数メッセージ+ファイル添付が必要な場合は共通ユーティリティを使用する。
+Import: `import { MessageBlockSchema, type Attachment, FILE_SIZE_WARNING_THRESHOLD, formatFileSize, saveFileToOPFS } from "../utils";`
+
+```tsx
+export const DataSchema = BaseNodeDataSchema.extend({
+  messages: z
+    .array(MessageBlockSchema)
+    .min(1)
+    .default([{ content: "", attachments: [] }]),
+});
+```
+
+ファイル保存には `templateEditorContext` (テンプレートID) または `executionContext` (セッションID) が必要:
+```tsx
+import { useTemplateEditorContextOptional } from "../contexts";
+
+const templateEditorContext = useTemplateEditorContextOptional();
+// saveFileToOPFS(file, { templateId: templateEditorContext?.templateId, sessionId: executionContext?.sessionId })
+```
+
+実装例: `SendMessageNode.tsx` を参照。
+
+---
+
+## UI Guidelines
+
+### Button Styling
+- Primary action (create/send): `nodrag btn btn-primary`
+- Destructive action (delete): `nodrag btn btn-error`
+- Neutral/ghost action: `nodrag btn btn-ghost`
+
+### Disabled State Rules
+- Edit-only inputs: `disabled={isExecuteMode || isLoading || isExecuted}`
+- Action button: `disabled={!isExecuteMode || isLoading || isExecuted}`
+
+### Node Width Guidelines
+
+| Width | px  | Use Case |
+|-------|-----|----------|
+| sm    | 192 | Single short input |
+| md    | 256 | Simple input(s) with label |
+| lg    | 480 | Complex forms |
+| xl    | 640 | Nested/complex layout (e.g., entry lists) |


### PR DESCRIPTION
## 概要

node-creator スキルに含まれていた誤った登録手順を修正し、CombinationSendMessageNode 実装を通じて得られた知見をパターンとして追加する。

## 背景・意思決定

実際にノードを実装する中で、スキルに2点の問題を発見した。  
①`TemplateEditor.tsx` の登録例が存在しないコード（`handleAddNode` の if/else 分岐）を示していた。実際は `NODE_CATEGORIES` 配列への追加のみで足りる。  
②`Node/index.ts` への re-export ステップがチェックリストから漏れていた。  

これらはスキルを使ってノードを実装しようとした際に確実に詰まる問題のため、今回の実装直後に修正する。

## 変更内容

- TemplateEditor.tsx の登録方法を実際のコードと一致するよう修正
- チェックリストに `Node/index.ts` re-export ステップを追加
- すべてのインタラクティブ要素へ `nodrag` クラスが必要であることを明記
- `isExecuted` を用いた正確な `disabled` 制御パターンを追加
- `sendMessage` API メソッドを Discord Client Methods に追加
- `ResourceSelector` パターンを patterns.md に追加
- メッセージブロック + ファイル添付パターン（`messageSchema.ts` 参照）を追加

## 確認手順

特になし（スキルファイルのみの変更）