### PR TITLE
テンプレートエクスポートの CSP エラーを修正

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" href="/favicon.ico" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://gm-assistant-bot-api.bidri.dev; img-src 'self' data: https://cdn.discordapp.com; style-src 'self' 'unsafe-inline'"
+      content="default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://gm-assistant-bot-api.bidri.dev; img-src 'self' data: https://cdn.discordapp.com; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:"
     />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -1,2 +1,2 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://gm-assistant-bot-api.bidri.dev; img-src 'self' data: https://cdn.discordapp.com; style-src 'self' 'unsafe-inline'
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://gm-assistant-bot-api.bidri.dev; img-src 'self' data: https://cdn.discordapp.com; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:


### PR DESCRIPTION
## 概要

テンプレートのエクスポートボタンを押しても ZIP ファイルがダウンロードされない問題を修正。本番・開発の両環境で再現していた。

## 背景・意思決定

`@zip.js/zip.js` は内部で `blob:` URL から Web Worker を生成する。CSP に `worker-src` ディレクティブが存在しない場合、ブラウザは `script-src` にフォールバックするが、そこに `blob:` が許可されていないため CSP 違反となりブロックされていた。

`script-src` に `blob:` を追加する方法もあるが、スクリプト全体の許可範囲が広がりすぎるため、用途を限定できる `worker-src` を独立して追加するアプローチを選択した。

## 変更内容

- CSP に `worker-src 'self' blob:` を追加し、`blob:` URL から生成される Web Worker を許可
- 開発環境（`index.html` の meta タグ）と本番環境（Cloudflare `_headers`）の両方に適用

## 確認手順

1. 開発サーバーを起動
2. テンプレート一覧画面でエクスポートボタンを押す
3. ZIP ファイルがダウンロードされることを確認
4. ブラウザの DevTools コンソールに CSP 違反エラーが表示されないことを確認