### PR TITLE
GameFlagsキーのUI表記を「フラグ名」に統一

### DIFF
--- a/frontend/src/components/Node/nodes/RandomSelectNode.tsx
+++ b/frontend/src/components/Node/nodes/RandomSelectNode.tsx
@@ -80,7 +80,7 @@ export const RandomSelectNode = ({
     }
 
     if (data.resultFlagKey.trim() === "") {
-      addToast({ message: "フラグキーを入力してください", status: "warning" });
+      addToast({ message: "フラグ名を入力してください", status: "warning" });
       return;
     }
 
@@ -145,7 +145,7 @@ export const RandomSelectNode = ({
         {!isExecuteMode && (
           <label className="form-control w-full mb-3">
             <div className="label">
-              <span className="label-text">フラグキー</span>
+              <span className="label-text">フラグ名</span>
             </div>
             <input
               type="text"

--- a/frontend/src/components/Node/nodes/SendMessageNode.tsx
+++ b/frontend/src/components/Node/nodes/SendMessageNode.tsx
@@ -460,7 +460,7 @@ export const SendMessageNode = ({
                         resourceType="gameFlag"
                         value={target.value}
                         onChange={(newKey) => handleChannelTargetChange(index, newKey)}
-                        placeholder="フラグキー"
+                        placeholder="フラグ名"
                         disabled={isExecuteMode || isLoading || isExecuted}
                       />
                     )}

--- a/frontend/src/components/Node/nodes/SetGameFlagNode.tsx
+++ b/frontend/src/components/Node/nodes/SetGameFlagNode.tsx
@@ -62,7 +62,7 @@ export const SetGameFlagNode = ({
     const value = data.flagValue.trim();
 
     if (key === "") {
-      addToast({ message: "フラグのKeyを入力してください", status: "warning" });
+      addToast({ message: "フラグ名を入力してください", status: "warning" });
       return;
     }
 
@@ -119,7 +119,7 @@ export const SetGameFlagNode = ({
       <BaseNodeContent>
         <label className="form-control w-full">
           <div className="label">
-            <span className="label-text">Key</span>
+            <span className="label-text">フラグ名</span>
           </div>
           <input
             type="text"

--- a/frontend/src/components/Node/utils/DynamicValueInput.tsx
+++ b/frontend/src/components/Node/utils/DynamicValueInput.tsx
@@ -118,7 +118,7 @@ export const DynamicValueInput = ({
           resourceType="gameFlag"
           value={value.flagKey}
           onChange={(key) => onChange({ type: "gameFlag", flagKey: key })}
-          placeholder="フラグキーを選択"
+          placeholder="フラグ名を選択"
           disabled={disabled}
         />
       )}


### PR DESCRIPTION
## 概要

ノード内でGameFlagsのキーを指す表現が「Key」「フラグキー」「フラグ名」の3種類に分かれていたため、「フラグ名」に統一した。

## 背景・意思決定

ConditionalBranchNode・SelectBranchNodeではすでに「フラグ名」が使われており、それを基準として他のノードを揃える形を選んだ。コード内部の変数名（`flagKey`、`resultFlagKey` など）はスキーマ変更を伴うため対象外とし、UI表示のみを変更している。

## 変更内容

- SetGameFlagNode のラベル・トーストで「フラグ名」を使うようになった
- RandomSelectNode のラベル・トーストで「フラグ名」を使うようになった
- SendMessageNode・DynamicValueInput のプレースホルダーで「フラグ名」を使うようになった

## 確認手順

1. ゲームフラグを設定するノード（SetGameFlagNode）を開き、キー入力欄のラベルが「フラグ名」になっていることを確認
2. ランダム選択ノード（RandomSelectNode）でも同様に「フラグ名」ラベルを確認
3. 各ノードでフラグ名を空のまま実行し、トーストに「フラグ名を入力してください」と表示されることを確認
4. SendMessageNode のチャンネルターゲット（gameFlag）でプレースホルダーが「フラグ名」になっていることを確認