### PR TITLE
ファイルのみのメッセージ送信を可能にする

### DIFF
--- a/backend/src/discord.ts
+++ b/backend/src/discord.ts
@@ -256,7 +256,7 @@ export async function sendMessage(token: string, data: SendMessageData) {
 
   await rest.post(Routes.channelMessages(data.channelId), {
     body: {
-      content: data.content,
+      content: data.content || undefined,
     },
     files: rawFiles.length > 0 ? rawFiles : undefined,
   });

--- a/backend/src/schemas.test.ts
+++ b/backend/src/schemas.test.ts
@@ -162,19 +162,24 @@ describe("addRoleToRoleMembersSchema", () => {
 });
 
 describe("sendMessageSchema", () => {
-  test("rejects empty content", () => {
+  test("rejects empty content without files", () => {
     expect(() => sendMessageSchema.parse({ channelId: "123", content: "" })).toThrow(ZodError);
   });
 
-  test("rejects whitespace-only content", () => {
+  test("rejects whitespace-only content without files", () => {
     expect(() => sendMessageSchema.parse({ channelId: "123", content: "   " })).toThrow(ZodError);
   });
 
-  test("accepts optional files field", () => {
-    const result = sendMessageSchema.parse({
-      channelId: "123",
-      content: "Message",
-    });
+  test("accepts empty content with files", () => {
+    const file = new File(["data"], "test.png", { type: "image/png" });
+    const result = sendMessageSchema.parse({ channelId: "123", content: "", files: file });
+    expect(result.content).toBe("");
+    expect(result.files).toBe(file);
+  });
+
+  test("accepts content without files", () => {
+    const result = sendMessageSchema.parse({ channelId: "123", content: "Message" });
+    expect(result.content).toBe("Message");
     expect(result.files).toBeUndefined();
   });
 });

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -44,11 +44,15 @@ export const addRoleToRoleMembersSchema = z.object({
   addRoleId: z.string().trim().nonempty(),
 });
 
-export const sendMessageSchema = z.object({
-  channelId: z.string().trim().nonempty(),
-  content: z.string().trim().nonempty(),
-  files: z.union([z.instanceof(File), z.array(z.instanceof(File)).max(4)]).optional(),
-});
+export const sendMessageSchema = z
+  .object({
+    channelId: z.string().trim().nonempty(),
+    content: z.string().trim().default(""),
+    files: z.union([z.instanceof(File), z.array(z.instanceof(File)).max(4)]).optional(),
+  })
+  .refine((data) => data.content !== "" || data.files !== undefined, {
+    message: "content or files is required",
+  });
 
 export type CreateRoleData = z.infer<typeof createRoleSchema>;
 export type DeleteRoleData = z.infer<typeof deleteRoleSchema>;

--- a/frontend/src/components/Node/nodes/CombinationSendMessageNode.tsx
+++ b/frontend/src/components/Node/nodes/CombinationSendMessageNode.tsx
@@ -459,9 +459,11 @@ export const CombinationSendMessageNode = ({
                         className="border border-base-content/10 rounded-lg p-3 space-y-2"
                       >
                         <div className="flex items-center justify-between">
-                          <span className="text-xs text-base-content/60">
-                            {message.content.length}/2000
-                          </span>
+                          {!(isExecuteMode && message.content === "") && (
+                            <span className="text-xs text-base-content/60">
+                              {message.content.length}/2000
+                            </span>
+                          )}
                           {!isExecuteMode && entry.messages.length > 1 && (
                             <button
                               type="button"
@@ -474,16 +476,18 @@ export const CombinationSendMessageNode = ({
                           )}
                         </div>
 
-                        <textarea
-                          className="nodrag textarea textarea-bordered w-full h-24"
-                          value={message.content}
-                          onChange={(e) =>
-                            handleContentChange(entryIndex, messageIndex, e.target.value)
-                          }
-                          placeholder="メッセージを入力"
-                          maxLength={2000}
-                          disabled={isExecuteMode || isLoading || isExecuted}
-                        />
+                        {!(isExecuteMode && message.content === "") && (
+                          <textarea
+                            className="nodrag textarea textarea-bordered w-full h-24"
+                            value={message.content}
+                            onChange={(e) =>
+                              handleContentChange(entryIndex, messageIndex, e.target.value)
+                            }
+                            placeholder="メッセージを入力"
+                            maxLength={2000}
+                            disabled={isExecuteMode || isLoading || isExecuted}
+                          />
+                        )}
 
                         <div>
                           <label className="text-xs font-semibold mb-1 block">

--- a/frontend/src/components/Node/nodes/SendMessageNode.tsx
+++ b/frontend/src/components/Node/nodes/SendMessageNode.tsx
@@ -502,9 +502,11 @@ export const SendMessageNode = ({
             >
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
-                  <span className="text-xs text-base-content/60">
-                    {message.content.length}/2000
-                  </span>
+                  {!(isExecuteMode && message.content === "") && (
+                    <span className="text-xs text-base-content/60">
+                      {message.content.length}/2000
+                    </span>
+                  )}
                 </div>
                 {!isExecuteMode && data.messages.length > 1 && (
                   <button
@@ -518,14 +520,16 @@ export const SendMessageNode = ({
                 )}
               </div>
 
-              <textarea
-                className="nodrag textarea textarea-bordered w-full h-24"
-                value={message.content}
-                onChange={(e) => handleContentChange(messageIndex, e.target.value)}
-                placeholder="メッセージを入力"
-                maxLength={2000}
-                disabled={isExecuteMode || isLoading || isExecuted}
-              />
+              {!(isExecuteMode && message.content === "") && (
+                <textarea
+                  className="nodrag textarea textarea-bordered w-full h-24"
+                  value={message.content}
+                  onChange={(e) => handleContentChange(messageIndex, e.target.value)}
+                  placeholder="メッセージを入力"
+                  maxLength={2000}
+                  disabled={isExecuteMode || isLoading || isExecuted}
+                />
+              )}
 
               <div>
                 <label className="text-xs font-semibold mb-1 block">


### PR DESCRIPTION
## 概要

テキストが空でファイルのみのメッセージを送信できるようになる。これまでは `content` が必須だったため、ファイルのみの送信がバリデーションエラーになっていた。

## 背景・意思決定

Discord API はファイルのみのメッセージ送信をサポートしているが、バックエンドの `sendMessageSchema` で `content` を `nonempty()` に制約していたため送信できなかった。制約を緩和するにあたり「content も files も両方なし」は依然として無効なので、`.refine()` で「どちらか一方は必須」というバリデーションを追加した。

## 変更内容

- ファイルのみ（content 空）のメッセージ送信がバリデーションを通過するようになった
- content が空の場合、Discord API に空文字ではなく `undefined` を送信するようになった（Discord の仕様に合わせた）
- 実行モードで content が空のメッセージブロックは textarea と文字数カウンタを非表示にし、UI がスッキリした

## 確認手順

1. SendMessageNode または CombinationSendMessageNode で content を空にしてファイルのみ添付する
2. テンプレートを実行し、ファイルのみのメッセージが Discord に送信されることを確認
3. 実行モードで content が空のメッセージブロックの textarea が表示されないことを確認
4. content もファイルも両方なしで送信しようとすると、バリデーションエラーになることを確認