### PR TITLE
選択肢ノードのやり直し機能と結果表示位置の改善

### DIFF
--- a/frontend/src/components/Node/nodes/RandomSelectNode.tsx
+++ b/frontend/src/components/Node/nodes/RandomSelectNode.tsx
@@ -65,6 +65,13 @@ export const RandomSelectNode = ({
     updateNodeData(id, { items: updatedItems });
   };
 
+  const handleReset = () => {
+    updateNodeData(id, {
+      selectedItem: undefined,
+      executedAt: undefined,
+    });
+  };
+
   const handleRandomSelect = async () => {
     if (!executionContext) {
       addToast({ message: "実行コンテキストがありません", status: "error" });
@@ -142,6 +149,16 @@ export const RandomSelectNode = ({
         )}
       </BaseNodeHeader>
       <BaseNodeContent maxHeight={NODE_CONTENT_HEIGHTS.md}>
+        {isExecuteMode && data.selectedItem && (
+          <div className="p-3 rounded-box bg-success/20 mb-3">
+            <div className="label">
+              <span className="label-text font-semibold">選択結果</span>
+            </div>
+            <p className="font-bold text-lg">{data.selectedItem}</p>
+            <p className="text-sm text-base-content/60 mt-1">フラグ: {data.resultFlagKey}</p>
+          </div>
+        )}
+
         {!isExecuteMode && (
           <label className="form-control w-full mb-3">
             <div className="label">
@@ -193,27 +210,23 @@ export const RandomSelectNode = ({
             </button>
           )}
         </div>
-
-        {isExecuteMode && data.selectedItem && (
-          <div className="mt-3 p-3 rounded-box bg-success/20">
-            <div className="label">
-              <span className="label-text font-semibold">選択結果</span>
-            </div>
-            <p className="font-bold text-lg">{data.selectedItem}</p>
-            <p className="text-sm text-base-content/60 mt-1">フラグ: {data.resultFlagKey}</p>
-          </div>
-        )}
       </BaseNodeContent>
       <BaseNodeFooter>
-        <button
-          type="button"
-          className="nodrag btn btn-primary"
-          onClick={handleRandomSelect}
-          disabled={!isExecuteMode || isLoading || isExecuted}
-        >
-          {isLoading && <span className="loading loading-spinner loading-sm"></span>}
-          ランダム選択
-        </button>
+        {isExecuteMode && isExecuted ? (
+          <button type="button" className="nodrag btn btn-outline btn-sm" onClick={handleReset}>
+            やり直す
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="nodrag btn btn-primary"
+            onClick={handleRandomSelect}
+            disabled={!isExecuteMode || isLoading}
+          >
+            {isLoading && <span className="loading loading-spinner loading-sm"></span>}
+            ランダム選択
+          </button>
+        )}
       </BaseNodeFooter>
       <BaseHandle id="target-1" type="target" position={Position.Left} />
       <BaseHandle id="source-1" type="source" position={Position.Right} />

--- a/frontend/src/components/Node/nodes/SelectBranchNode.tsx
+++ b/frontend/src/components/Node/nodes/SelectBranchNode.tsx
@@ -124,6 +124,14 @@ export const SelectBranchNode = ({
     updateNodeData(id, { flagName: newKey });
   };
 
+  const handleReset = () => {
+    updateNodeData(id, {
+      selectedValue: undefined,
+      executedAt: undefined,
+    });
+    setSelectedOption("");
+  };
+
   const handleExecute = async () => {
     if (!executionContext) {
       addToast({ message: "実行コンテキストがありません", status: "error" });
@@ -197,6 +205,13 @@ export const SelectBranchNode = ({
       </BaseNodeHeader>
 
       <BaseNodeContent maxHeight={NODE_CONTENT_HEIGHTS.md}>
+        {isExecuteMode && isExecuted && (
+          <div className="bg-success/20 rounded p-3 text-center mb-2">
+            <div className="text-sm text-base-content/70">選択結果</div>
+            <div className="font-semibold">{selectedLabel}</div>
+          </div>
+        )}
+
         {!isExecuteMode && (
           <>
             <label className="form-control w-full">
@@ -229,12 +244,7 @@ export const SelectBranchNode = ({
               フラグ名: <span className="font-mono">{data.flagName || "(未設定)"}</span>
             </div>
 
-            {isExecuted ? (
-              <div className="bg-success/20 rounded p-3 text-center">
-                <div className="text-sm text-base-content/70">選択結果</div>
-                <div className="font-semibold">{selectedLabel}</div>
-              </div>
-            ) : (
+            {!isExecuted && (
               <div className="space-y-2">
                 {data.options.map((option) => (
                   <label
@@ -260,15 +270,25 @@ export const SelectBranchNode = ({
       </BaseNodeContent>
 
       <BaseNodeFooter>
-        <button
-          type="button"
-          className="nodrag btn btn-primary w-full"
-          onClick={handleExecute}
-          disabled={!isExecuteMode || isExecuted || isLoading || !selectedOption}
-        >
-          {isLoading && <span className="loading loading-spinner loading-sm" />}
-          確定する
-        </button>
+        {isExecuteMode && isExecuted ? (
+          <button
+            type="button"
+            className="nodrag btn btn-outline btn-sm w-full"
+            onClick={handleReset}
+          >
+            やり直す
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="nodrag btn btn-primary w-full"
+            onClick={handleExecute}
+            disabled={!isExecuteMode || isLoading || !selectedOption}
+          >
+            {isLoading && <span className="loading loading-spinner loading-sm" />}
+            確定する
+          </button>
+        )}
       </BaseNodeFooter>
 
       <BaseHandle id="target-1" type="target" position={Position.Left} />


### PR DESCRIPTION
## 概要

SelectBranchNode と RandomSelectNode で、一度実行した選択をやり直せるようになった。また、選択結果がノードボディの最上部に表示されるようになり、結果が視認しやすくなった。

## 背景・意思決定

従来は実行後に選択を変更する手段がなく、誤った選択をした場合にノードを作り直す必要があった。リセット時にゲームセッションのフラグを削除しない設計としたのは、再実行時に上書きされるため実害がなく、削除処理の複雑さを避けるため。

## 変更内容

- 実行済みの状態から選択をリセットし、再選択できるようになった（両ノード共通）
- 選択結果の表示がフッター付近からボディ上部に移動し、確認しやすくなった
- 実行済み時のフッターボタンが「やり直す」に切り替わり、操作の意図が明確になった

## 確認手順

**SelectBranchNode:**
1. execute モードでラジオボタンから選択肢を選ぶ
2. 「確定する」を押す → 結果がボディ上部に表示され、フッターが「やり直す」に変わる
3. 「やり直す」を押す → 選択がリセットされ再選択できる

**RandomSelectNode:**
1. execute モードで「ランダム選択」を押す → 結果がボディ上部に表示され、フッターが「やり直す」に変わる
2. 「やり直す」を押す → リセットされ再度ランダム選択できる