### PR TITLE
実行モードでファイルDnDエリアを非表示にする

### DIFF
--- a/frontend/src/components/Node/nodes/CombinationSendMessageNode.tsx
+++ b/frontend/src/components/Node/nodes/CombinationSendMessageNode.tsx
@@ -566,65 +566,68 @@ export const CombinationSendMessageNode = ({
                             </p>
                           )}
 
-                          {message.attachments.length < 4 ? (
+                          {!isExecuteMode && (
                             <>
-                              <input
-                                ref={(el) => {
-                                  if (el) fileInputRefs.current.set(dragKey, el);
-                                }}
-                                type="file"
-                                multiple
-                                className="hidden"
-                                onChange={(e) => handleFileAdd(entryIndex, messageIndex, e)}
-                                disabled={isExecuteMode || isLoading || isExecuted}
-                              />
-                              <div
-                                className={cn(
-                                  "nodrag",
-                                  "flex flex-col items-center justify-center gap-1",
-                                  "rounded-lg border-2 p-4 cursor-pointer",
-                                  "transition-all duration-200",
-                                  draggingKey === dragKey
-                                    ? "border-primary bg-primary/10 border-solid"
-                                    : "border-dashed border-base-content/30 hover:border-base-content/50 hover:bg-base-200/50",
-                                  (isExecuteMode || isLoading || isExecuted) &&
-                                    "opacity-50 pointer-events-none cursor-not-allowed",
-                                )}
-                                onDragOver={handleDragOver}
-                                onDragEnter={(e) => handleDragEnter(dragKey, e)}
-                                onDragLeave={(e) => handleDragLeave(dragKey, e)}
-                                onDrop={(e) => handleDrop(entryIndex, messageIndex, dragKey, e)}
-                                onClick={() =>
-                                  !isExecuteMode &&
-                                  !isLoading &&
-                                  !isExecuted &&
-                                  fileInputRefs.current.get(dragKey)?.click()
-                                }
-                              >
-                                {draggingKey === dragKey ? (
-                                  <>
-                                    <LuDownload className="w-6 h-6 text-primary" />
-                                    <span className="text-sm text-primary font-medium">
-                                      ファイルをドロップ
-                                    </span>
-                                    <span className="text-xs text-primary/70">
-                                      あと{4 - message.attachments.length}個追加できます
-                                    </span>
-                                  </>
-                                ) : (
-                                  <>
-                                    <LuUpload className="w-5 h-5 text-base-content/60" />
-                                    <span className="text-sm text-base-content/60">
-                                      ファイルをドロップまたはクリックして追加
-                                    </span>
-                                  </>
-                                )}
-                              </div>
+                              {message.attachments.length < 4 ? (
+                                <>
+                                  <input
+                                    ref={(el) => {
+                                      if (el) fileInputRefs.current.set(dragKey, el);
+                                    }}
+                                    type="file"
+                                    multiple
+                                    className="hidden"
+                                    onChange={(e) => handleFileAdd(entryIndex, messageIndex, e)}
+                                    disabled={isLoading || isExecuted}
+                                  />
+                                  <div
+                                    className={cn(
+                                      "nodrag",
+                                      "flex flex-col items-center justify-center gap-1",
+                                      "rounded-lg border-2 p-4 cursor-pointer",
+                                      "transition-all duration-200",
+                                      draggingKey === dragKey
+                                        ? "border-primary bg-primary/10 border-solid"
+                                        : "border-dashed border-base-content/30 hover:border-base-content/50 hover:bg-base-200/50",
+                                      (isLoading || isExecuted) &&
+                                        "opacity-50 pointer-events-none cursor-not-allowed",
+                                    )}
+                                    onDragOver={handleDragOver}
+                                    onDragEnter={(e) => handleDragEnter(dragKey, e)}
+                                    onDragLeave={(e) => handleDragLeave(dragKey, e)}
+                                    onDrop={(e) => handleDrop(entryIndex, messageIndex, dragKey, e)}
+                                    onClick={() =>
+                                      !isLoading &&
+                                      !isExecuted &&
+                                      fileInputRefs.current.get(dragKey)?.click()
+                                    }
+                                  >
+                                    {draggingKey === dragKey ? (
+                                      <>
+                                        <LuDownload className="w-6 h-6 text-primary" />
+                                        <span className="text-sm text-primary font-medium">
+                                          ファイルをドロップ
+                                        </span>
+                                        <span className="text-xs text-primary/70">
+                                          あと{4 - message.attachments.length}個追加できます
+                                        </span>
+                                      </>
+                                    ) : (
+                                      <>
+                                        <LuUpload className="w-5 h-5 text-base-content/60" />
+                                        <span className="text-sm text-base-content/60">
+                                          ファイルをドロップまたはクリックして追加
+                                        </span>
+                                      </>
+                                    )}
+                                  </div>
+                                </>
+                              ) : (
+                                <p className="text-xs text-base-content/60 text-center py-2">
+                                  添付ファイルは最大4つまでです
+                                </p>
+                              )}
                             </>
-                          ) : (
-                            <p className="text-xs text-base-content/60 text-center py-2">
-                              添付ファイルは最大4つまでです
-                            </p>
                           )}
                         </div>
                       </div>

--- a/frontend/src/components/Node/nodes/SendMessageNode.tsx
+++ b/frontend/src/components/Node/nodes/SendMessageNode.tsx
@@ -602,65 +602,68 @@ export const SendMessageNode = ({
                   </p>
                 )}
 
-                {message.attachments.length < 4 ? (
+                {!isExecuteMode && (
                   <>
-                    <input
-                      ref={(el) => {
-                        if (el) fileInputRefs.current.set(messageIndex, el);
-                      }}
-                      type="file"
-                      multiple
-                      className="hidden"
-                      onChange={(e) => handleFileAdd(messageIndex, e)}
-                      disabled={isExecuteMode || isLoading || isExecuted}
-                    />
-                    <div
-                      className={cn(
-                        "nodrag",
-                        "flex flex-col items-center justify-center gap-1",
-                        "rounded-lg border-2 p-4 cursor-pointer",
-                        "transition-all duration-200",
-                        draggingIndex === messageIndex
-                          ? "border-primary bg-primary/10 border-solid"
-                          : "border-dashed border-base-content/30 hover:border-base-content/50 hover:bg-base-200/50",
-                        (isExecuteMode || isLoading || isExecuted) &&
-                          "opacity-50 pointer-events-none cursor-not-allowed",
-                      )}
-                      onDragOver={handleDragOver}
-                      onDragEnter={(e) => handleDragEnter(messageIndex, e)}
-                      onDragLeave={(e) => handleDragLeave(messageIndex, e)}
-                      onDrop={(e) => handleDrop(messageIndex, e)}
-                      onClick={() =>
-                        !isExecuteMode &&
-                        !isLoading &&
-                        !isExecuted &&
-                        fileInputRefs.current.get(messageIndex)?.click()
-                      }
-                    >
-                      {draggingIndex === messageIndex ? (
-                        <>
-                          <LuDownload className="w-6 h-6 text-primary" />
-                          <span className="text-sm text-primary font-medium">
-                            ファイルをドロップ
-                          </span>
-                          <span className="text-xs text-primary/70">
-                            あと{4 - message.attachments.length}個追加できます
-                          </span>
-                        </>
-                      ) : (
-                        <>
-                          <LuUpload className="w-5 h-5 text-base-content/60" />
-                          <span className="text-sm text-base-content/60">
-                            ファイルをドロップまたはクリックして追加
-                          </span>
-                        </>
-                      )}
-                    </div>
+                    {message.attachments.length < 4 ? (
+                      <>
+                        <input
+                          ref={(el) => {
+                            if (el) fileInputRefs.current.set(messageIndex, el);
+                          }}
+                          type="file"
+                          multiple
+                          className="hidden"
+                          onChange={(e) => handleFileAdd(messageIndex, e)}
+                          disabled={isLoading || isExecuted}
+                        />
+                        <div
+                          className={cn(
+                            "nodrag",
+                            "flex flex-col items-center justify-center gap-1",
+                            "rounded-lg border-2 p-4 cursor-pointer",
+                            "transition-all duration-200",
+                            draggingIndex === messageIndex
+                              ? "border-primary bg-primary/10 border-solid"
+                              : "border-dashed border-base-content/30 hover:border-base-content/50 hover:bg-base-200/50",
+                            (isLoading || isExecuted) &&
+                              "opacity-50 pointer-events-none cursor-not-allowed",
+                          )}
+                          onDragOver={handleDragOver}
+                          onDragEnter={(e) => handleDragEnter(messageIndex, e)}
+                          onDragLeave={(e) => handleDragLeave(messageIndex, e)}
+                          onDrop={(e) => handleDrop(messageIndex, e)}
+                          onClick={() =>
+                            !isLoading &&
+                            !isExecuted &&
+                            fileInputRefs.current.get(messageIndex)?.click()
+                          }
+                        >
+                          {draggingIndex === messageIndex ? (
+                            <>
+                              <LuDownload className="w-6 h-6 text-primary" />
+                              <span className="text-sm text-primary font-medium">
+                                ファイルをドロップ
+                              </span>
+                              <span className="text-xs text-primary/70">
+                                あと{4 - message.attachments.length}個追加できます
+                              </span>
+                            </>
+                          ) : (
+                            <>
+                              <LuUpload className="w-5 h-5 text-base-content/60" />
+                              <span className="text-sm text-base-content/60">
+                                ファイルをドロップまたはクリックして追加
+                              </span>
+                            </>
+                          )}
+                        </div>
+                      </>
+                    ) : (
+                      <p className="text-xs text-base-content/60 text-center py-2">
+                        添付ファイルは最大4つまでです
+                      </p>
+                    )}
                   </>
-                ) : (
-                  <p className="text-xs text-base-content/60 text-center py-2">
-                    添付ファイルは最大4つまでです
-                  </p>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## 概要

実行モード中、ファイルのドラッグ＆ドロップエリアが不要なスペースを占有していた問題を修正する。
`SendMessageNode` と `CombinationSendMessageNode` の両方で、実行モード時に DnD エリアを DOM から完全に除外するようにした。

## 背景・意思決定

既存の実装では、DnD エリアに `opacity-50 pointer-events-none` を付与して CSS レベルで無効化していた。しかし、追加・削除ボタンなど他の編集用 UI 要素は `{!isExecuteMode && (...)}` で DOM から除外されており、DnD エリアだけが例外的に残ってスペースを占有していた。

他の要素と一貫したアプローチ（DOM から完全に除外）を採用することで、実行モードの UI をよりコンパクトにする。

## 変更内容

- 実行モードでファイル DnD エリア（input 要素・ドロップゾーン・添付上限メッセージを含むブロック全体）が非表示になる
- ローディング中・実行済み状態での CSS 無効化は引き続き機能する

## 確認手順

1. `SendMessageNode` または `CombinationSendMessageNode` をワークフローに配置する
2. 編集モードでファイル DnD エリアが表示されることを確認する
3. 実行モードに切り替えて、DnD エリアが消えてスペースが詰まることを確認する
4. 実行モードを終了して、DnD エリアが再表示されることを確認する