### PR TITLE
fix: PortaledSelect の選択肢が段組みになる問題を修正

### DIFF
--- a/frontend/src/components/Node/utils/PortaledSelect.tsx
+++ b/frontend/src/components/Node/utils/PortaledSelect.tsx
@@ -149,7 +149,7 @@ export function PortaledSelect({
             />
             <ul
               ref={menuRef}
-              className="menu bg-base-100 shadow-lg rounded-box border border-base-300 z-9999 max-h-48 overflow-y-auto"
+              className="menu flex-nowrap bg-base-100 shadow-lg rounded-box border border-base-300 z-9999 max-h-48 overflow-y-auto"
               style={{
                 position: "fixed",
                 top: position.top,


### PR DESCRIPTION
## 概要

RecordCombinationNode などで PortaledSelect を開いたとき、選択肢が多いと横に並んで段組みになり、横スクロールバーが表示される問題を修正した。修正後は選択肢が常に縦1列に並び、縦スクロールで操作できる。

## 背景・意思決定

DaisyUI の `.menu` クラスは `flex-wrap: wrap` を持つため、ポップアップの幅（約210px）に対して選択肢の合計幅が超えると折り返して複数列になる。この状態で横スクロールバーが出現すると、背景の `fixed inset-0` オーバーレイがスクロール操作を妨げてポップアップが閉じてしまう二次問題も起きていた。

`flex-nowrap` を追加して折り返しを無効にすることで、既存の `max-h-48 overflow-y-auto` による縦スクロールが正しく機能するようになる。Tailwind ユーティリティ1クラスの追加のみで解決できるため、この方針を採用した。

## 変更内容

- PortaledSelect のドロップダウンメニューが、選択肢の数に関わらず常に縦1列で表示されるようになった
- 横スクロールバーが表示されなくなり、オーバーレイによってポップアップが意図せず閉じる問題も解消された

## 確認手順

1. RecordCombinationNode をテンプレートエディタに追加する
2. 組み合わせ対象のロールが多い状態で PortaledSelect を開く
3. 選択肢が縦1列に並び、縦スクロールで操作できることを確認する
4. 横スクロールバーが表示されないことを確認する