### PR TITLE
テンプレートからセッション作成時の添付ファイルパス変換を修正

### DIFF
--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -4,25 +4,10 @@ import { useLiveQuery } from "dexie-react-hooks";
 import { type MouseEvent, useEffect, useState } from "react";
 
 import { ApiClient } from "@/api";
-import { db } from "@/db";
+import { db, type ReactFlowData } from "@/db";
 import { type GuildSchema } from "@/db";
-import { FileSystem } from "@/fileSystem";
+import { FileSystem, convertFilePathsInReactFlowData } from "@/fileSystem";
 import { useToast } from "@/toast/ToastProvider";
-
-const convertFilePaths = (reactFlowData: string, templateId: number, sessionId: number): string => {
-  const data = JSON.parse(reactFlowData);
-  for (const node of data.nodes) {
-    if (node.data?.attachments) {
-      node.data.attachments = node.data.attachments.map(
-        (a: { filePath: string; fileName: string; fileSize: number }) => ({
-          ...a,
-          filePath: a.filePath.replace(`template/${templateId}/`, `session/${sessionId}/`),
-        }),
-      );
-    }
-  }
-  return JSON.stringify(data);
-};
 
 interface Props {
   onCreate?: (created: {}) => Promise<void>;
@@ -105,11 +90,11 @@ export const CreateSession = ({ onCreate, onCancel }: Props) => {
       const fileSystem = new FileSystem();
       await fileSystem.copyTemplateFilesToSession(selectedTemplateId, newSessionId);
 
-      const convertedReactFlowData = convertFilePaths(
-        template.reactFlowData,
-        selectedTemplateId,
-        newSessionId,
+      const parsed: ReactFlowData = JSON.parse(template.reactFlowData);
+      const converted = convertFilePathsInReactFlowData(parsed, (filePath) =>
+        filePath.replace(`template/${selectedTemplateId}/`, `session/${newSessionId}/`),
       );
+      const convertedReactFlowData = JSON.stringify(converted);
       await db.GameSession.update(newSessionId, {
         reactFlowData: convertedReactFlowData,
       });


### PR DESCRIPTION
## 概要

テンプレートからセッションを作成した際、添付ファイルを含むノード（`SendMessageNode`・`CombinationSendMessageNode`）のファイルパスが正しく変換されず、セッション実行時にファイル参照が壊れていたバグを修正する。

## 背景・意思決定

元の `convertFilePaths` 関数は `node.data.attachments` を直接参照していたが、実際のデータ構造は以下のように深くネストされている：

- `SendMessageNode`: `node.data.messages[].attachments[].filePath`
- `CombinationSendMessageNode`: `node.data.entries[].messages[].attachments[].filePath`

そのため変換処理が一切機能せず、ファイルは `template/{id}/...` のままセッションに保存されていた。

`fileSystem.ts` には正しいデータ構造を走査する `convertFilePathsInReactFlowData` が既に存在しテスト済みだったため、独自実装を廃止してこれを利用する方針とした。

## 変更内容

- テンプレート→セッション変換時に、添付ファイルの `filePath` が `template/{id}/...` から `session/{id}/...` へ正しく書き換えられるようになった
- バグのあった `convertFilePaths` 関数を削除し、既存の `convertFilePathsInReactFlowData` に統一

## 確認手順

1. 添付ファイル付きメッセージを含むテンプレートを作成する
2. そのテンプレートからセッションを作成する
3. セッションを開き、該当ノードで添付ファイルが正しく表示・参照されることを確認する