### PR TITLE
同一ファイルを繰り返しアップロードしても OPFS に重複保存されないようにする

### DIFF
--- a/frontend/src/components/Node/utils/messageSchema.test.ts
+++ b/frontend/src/components/Node/utils/messageSchema.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+import { formatFileSize, saveFileToOPFS } from "./messageSchema";
+
+const mockReadFile = mock(async (_path: string): Promise<File> => {
+  throw new DOMException("Not found", "NotFoundError");
+});
+const mockWriteFile = mock(async (_path: string, _file: File): Promise<void> => {});
+
+void mock.module("@/fileSystem", () => ({
+  FileSystem: class {
+    readFile = mockReadFile;
+    writeFile = mockWriteFile;
+  },
+}));
+
+const makeFile = (name: string, content: string): File =>
+  new File([content], name, { type: "text/plain" });
+
+beforeEach(() => {
+  mockReadFile.mockReset();
+  mockWriteFile.mockReset();
+  mockReadFile.mockImplementation(async (_path: string): Promise<File> => {
+    throw new DOMException("Not found", "NotFoundError");
+  });
+  mockWriteFile.mockImplementation(async (_path: string, _file: File): Promise<void> => {});
+});
+
+describe("saveFileToOPFS", () => {
+  it("新規ファイル（templateId）はベースパスに保存される", async () => {
+    const file = makeFile("image.png", "content");
+
+    const result = await saveFileToOPFS(file, { templateId: 1 });
+
+    expect(result).toBe("template/1/image.png");
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    expect(mockWriteFile.mock.calls[0][0]).toBe("template/1/image.png");
+  });
+
+  it("新規ファイル（sessionId）は session/ パスに保存される", async () => {
+    const file = makeFile("audio.mp3", "data");
+
+    const result = await saveFileToOPFS(file, { sessionId: 42 });
+
+    expect(result).toBe("session/42/audio.mp3");
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    expect(mockWriteFile.mock.calls[0][0]).toBe("session/42/audio.mp3");
+  });
+
+  it("templateId も sessionId も未指定の場合はエラーをスローする", async () => {
+    const file = makeFile("file.txt", "data");
+
+    expect(saveFileToOPFS(file, {})).rejects.toThrow("templateIdまたはsessionIdが必要です");
+  });
+
+  it("同名・同内容のファイルは書き込みなしで既存パスを返す", async () => {
+    const content = "identical content";
+    const existingFile = makeFile("photo.jpg", content);
+    const newFile = makeFile("photo.jpg", content);
+
+    mockReadFile.mockImplementation(async (_path: string) => existingFile);
+
+    const result = await saveFileToOPFS(newFile, { templateId: 5 });
+
+    expect(result).toBe("template/5/photo.jpg");
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("同名・異内容のファイルはランダムサブディレクトリに保存される", async () => {
+    const existingFile = makeFile("photo.jpg", "old content");
+    const newFile = makeFile("photo.jpg", "new content");
+
+    mockReadFile.mockImplementation(async (_path: string) => existingFile);
+
+    const result = await saveFileToOPFS(newFile, { templateId: 5 });
+
+    expect(result).toMatch(/^template\/5\/[0-9a-f]{8}\/photo\.jpg$/);
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    expect(mockWriteFile.mock.calls[0][0]).toBe(result);
+  });
+});
+
+describe("formatFileSize", () => {
+  it("1024 バイト未満は B 単位で表示する", () => {
+    expect(formatFileSize(0)).toBe("0 B");
+    expect(formatFileSize(512)).toBe("512 B");
+    expect(formatFileSize(1023)).toBe("1023 B");
+  });
+
+  it("1024 バイト以上 1MB 未満は KB 単位で表示する", () => {
+    expect(formatFileSize(1024)).toBe("1.0 KB");
+    expect(formatFileSize(1536)).toBe("1.5 KB");
+    expect(formatFileSize(1024 * 1024 - 1)).toBe("1024.0 KB");
+  });
+
+  it("1MB 以上は MB 単位で表示する", () => {
+    expect(formatFileSize(1024 * 1024)).toBe("1.0 MB");
+    expect(formatFileSize(1024 * 1024 * 2.5)).toBe("2.5 MB");
+  });
+});

--- a/frontend/src/components/Node/utils/messageSchema.ts
+++ b/frontend/src/components/Node/utils/messageSchema.ts
@@ -23,6 +23,13 @@ export const formatFileSize = (bytes: number): string => {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 };
 
+const computeSHA256 = async (data: Blob): Promise<string> => {
+  const buffer = await data.arrayBuffer();
+  const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
+  const hashArray = new Uint8Array(hashBuffer);
+  return Array.from(hashArray, (b) => b.toString(16).padStart(2, "0")).join("");
+};
+
 export const saveFileToOPFS = async (
   file: File,
   options: { templateId?: number; sessionId?: number },
@@ -39,11 +46,27 @@ export const saveFileToOPFS = async (
     throw new Error("templateIdまたはsessionIdが必要です");
   }
 
-  let basePath = `${baseDir}/${file.name}`;
+  const basePath = `${baseDir}/${file.name}`;
 
-  if (await fs.fileExists(basePath)) {
+  let existingFile: File | null = null;
+  try {
+    existingFile = await fs.readFile(basePath);
+  } catch {
+    // file doesn't exist
+  }
+
+  if (existingFile) {
+    const [existingHash, newHash] = await Promise.all([
+      computeSHA256(existingFile),
+      computeSHA256(file),
+    ]);
+    if (existingHash === newHash) {
+      return basePath;
+    }
     const randomDir = crypto.randomUUID().slice(0, 8);
-    basePath = `${baseDir}/${randomDir}/${file.name}`;
+    const newPath = `${baseDir}/${randomDir}/${file.name}`;
+    await fs.writeFile(newPath, file);
+    return newPath;
   }
 
   await fs.writeFile(basePath, file);


### PR DESCRIPTION
## 概要

同じファイルを何度アップロードしても、OPFS 上に同一内容のファイルが重複して保存されなくなる。
既存ファイルと内容が一致する場合は書き込みをスキップし、既存パスをそのまま返す。

## 背景・意思決定

従来の実装は同名ファイルが存在するだけで無条件にランダムサブディレクトリへ新規保存していた。
同じ画像や音声を繰り返し添付する操作が多いため、内容比較なしでは OPFS のストレージが際限なく膨らむ。

内容比較には SHA-256 を採用した。`crypto.subtle.digest` はブラウザ/Bun 双方で利用可能なため、外部ライブラリ不要で実装できる。
比較範囲はベースパス（`{dir}/{filename}`）のみに限定している。ランダムサブディレクトリ内まで再帰走査するのは過剰であり、主要な重複ケース（同一ファイルの繰り返しアップロード）を防ぐには十分。

## 変更内容

- 同名・同内容のファイルをアップロードした場合、追加の書き込みなしに既存パスが再利用される
- 同名・異内容のファイルは従来どおりランダムサブディレクトリに保存される
- `fileExists` による二度読みを廃止し、`readFile` の try-catch 一回で済むよう整理

## 確認手順

1. テンプレートまたはセッションのメッセージノードで同じ画像ファイルを複数回添付する
2. OPFS の `template/{id}/` または `session/{id}/` ディレクトリを DevTools の Storage で確認し、同一ファイルが重複して作られていないことを検証する
3. 異なる内容のファイルを同名でアップロードした場合に、ランダムサブディレクトリへ別途保存されることを確認する