### PR TITLE
実行モードの「利用可能なロール/チャンネル」表示を削除

### DIFF
--- a/frontend/src/components/Node/nodes/ChangeChannelPermissionNode.tsx
+++ b/frontend/src/components/Node/nodes/ChangeChannelPermissionNode.tsx
@@ -281,16 +281,6 @@ export const ChangeChannelPermissionNode = ({
               </button>
             )}
           </div>
-
-          {/* Show available roles and channels in execute mode */}
-          {isExecuteMode && (roles.length > 0 || channels.length > 0) && (
-            <div className="text-xs text-base-content/60 space-y-1">
-              {channels.length > 0 && (
-                <p>利用可能なチャンネル: {channels.map((c) => c.name).join(", ")}</p>
-              )}
-              {roles.length > 0 && <p>利用可能なロール: {roles.map((r) => r.name).join(", ")}</p>}
-            </div>
-          )}
         </div>
       </BaseNodeContent>
       <BaseNodeFooter>

--- a/frontend/src/components/Node/nodes/CreateChannelNode.tsx
+++ b/frontend/src/components/Node/nodes/CreateChannelNode.tsx
@@ -343,13 +343,6 @@ export const CreateChannelNode = ({
                   </button>
                 )}
               </div>
-
-              {/* Show available roles in execute mode */}
-              {isExecuteMode && roles.length > 0 && (
-                <p className="text-xs text-base-content/60 mt-2">
-                  利用可能なロール: {roles.map((r) => r.name).join(", ")}
-                </p>
-              )}
             </div>
           ))}
         </div>

--- a/frontend/src/components/Node/nodes/SendMessageNode.tsx
+++ b/frontend/src/components/Node/nodes/SendMessageNode.tsx
@@ -679,12 +679,6 @@ export const SendMessageNode = ({
               + メッセージを追加
             </button>
           )}
-
-          {isExecuteMode && channels.length > 0 && (
-            <p className="text-xs text-base-content/60">
-              利用可能なチャンネル: {channels.map((c) => c.name).join(", ")}
-            </p>
-          )}
         </div>
       </BaseNodeContent>
 


### PR DESCRIPTION
## 概要

ノードの実行モードで表示されていた「利用可能なロール」「利用可能なチャンネル」のラベルを削除する。ResourceSelector の導入により、ユーザーはセレクタから直接リソースを選択できるようになったため、これらの表示は不要となった。

## 背景・意思決定

ResourceSelector 導入以前は、実行モードで利用できるロール・チャンネルの一覧をテキスト表示することでユーザーに選択肢を伝えていた。現在はセレクタUIから直接選べるため、テキスト表示は重複した情報となっている。

`roles` / `channels` の state と useEffect は各ノードの実行ハンドラ（DB検索・API呼び出し）でも使用されているため、JSXの表示部分のみを削除した。

## 変更内容

- `ChangeChannelPermissionNode`・`SendMessageNode`・`CreateChannelNode` の実行モードで、利用可能なロール/チャンネルのテキスト表示が非表示になる

## 確認手順

1. ワークフローエディタでいずれかのノード（ChangeChannelPermission / SendMessage / CreateChannel）を配置する
2. 実行モードに切り替える
3. 「利用可能なロール」「利用可能なチャンネル」のテキストが表示されないことを確認する
4. 実行ボタンを押して、実行自体は正常に動作することを確認する