### PR TITLE
PortaledSelect のドロップダウンメニュー内でスクロールできないバグを修正

### DIFF
--- a/frontend/src/components/Node/utils/PortaledSelect.tsx
+++ b/frontend/src/components/Node/utils/PortaledSelect.tsx
@@ -100,7 +100,8 @@ export function PortaledSelect({
       if (e.key === "Escape") setIsOpen(false);
     };
 
-    const handleScroll = () => {
+    const handleScroll = (e: Event) => {
+      if (menuRef.current?.contains(e.target as Node)) return;
       setIsOpen(false);
     };
 
@@ -142,11 +143,7 @@ export function PortaledSelect({
         createPortal(
           <>
             {/* 背景オーバーレイ - クリックで閉じる */}
-            <div
-              className="fixed inset-0 z-9998"
-              onClick={() => setIsOpen(false)}
-              onWheel={() => setIsOpen(false)}
-            />
+            <div className="fixed inset-0 z-9998" onClick={() => setIsOpen(false)} />
             <ul
               ref={menuRef}
               className="menu flex-nowrap bg-base-100 shadow-lg rounded-box border border-base-300 z-9999 max-h-48 overflow-y-auto"


### PR DESCRIPTION
## 概要

PortaledSelect のドロップダウンメニューを開いた状態で、選択肢が多くスクロールが必要な場合にスクロール操作ができなかった問題を修正した。スクロールバーをドラッグしてもホイールを回しても、操作するたびにメニューが閉じてしまっていた。

## 背景・意思決定

原因は2つあった。

1. **scroll イベントリスナー（capture phase）**: `window.addEventListener("scroll", handler, true)` で capture phase 登録しているため、メニュー内の `<ul>` 要素で発生したスクロールイベントも捕捉してしまっていた。capture phase をやめると、React Flow ペイン等でのスクロール時に閉じなくなるため、capture phase は維持しつつイベントの発生元がメニュー内かを判定して除外する方式を選んだ。

2. **背景オーバーレイの `onWheel` ハンドラ**: メニュー内でのホイール操作はイベントバブリングでオーバーレイまで伝播し、`onWheel={() => setIsOpen(false)}` が発火していた。メニュー外のホイールスクロールは capture phase の scroll リスナーで対応できるため、`onWheel` は不要と判断して削除した。

## 変更内容

- メニュー内でのスクロール（スクロールバードラッグ・ホイール両方）が正しく動作するようになった
- メニュー外クリック・Escape キー・ウィンドウスクロールなど既存の閉じる挙動は維持される

## 確認手順

1. `bun run --bun dev` で開発サーバーを起動
2. ResourceSelector などで選択肢が多い状態（チャンネル・ロール等）を用意する
3. ドロップダウンを開き、メニュー内でマウスホイールおよびスクロールバードラッグでスクロールできることを確認
4. メニュー外クリック・Escape キー・React Flow ペインのスクロールでメニューが閉じることを確認