### PR TITLE
エクスポート ZIP のファイル重複をコンテンツハッシュで排除する

### DIFF
--- a/frontend/src/fileSystem.test.ts
+++ b/frontend/src/fileSystem.test.ts
@@ -2,7 +2,11 @@ import { describe, test, expect, beforeEach, mock } from "bun:test";
 
 import type { ReactFlowData } from "./db";
 
-import { FileSystem, convertFilePathsInReactFlowData } from "./fileSystem";
+import {
+  FileSystem,
+  collectFilePathsFromReactFlowData,
+  convertFilePathsInReactFlowData,
+} from "./fileSystem";
 
 // 実際のファイルストレージを持つ拡張OPFSモック
 class MockFileSystemStorage {
@@ -280,6 +284,153 @@ describe("FileSystem", () => {
     test("テンプレートが見つからない場合はエラーをスローする", async () => {
       expect(fs.exportTemplate(999)).rejects.toThrow("テンプレートが見つかりません");
     });
+  });
+});
+
+describe("collectFilePathsFromReactFlowData", () => {
+  const makeReactFlowData = (nodes: unknown[]): ReactFlowData => ({
+    nodes,
+    edges: [],
+    viewport: { x: 0, y: 0, zoom: 1 },
+  });
+
+  test("SendMessageノードから全添付ファイルパスを収集する", () => {
+    const data = makeReactFlowData([
+      {
+        type: "SendMessage",
+        data: {
+          messages: [
+            {
+              content: "hello",
+              attachments: [
+                { fileName: "img.png", filePath: "template/1/img.png", fileSize: 100 },
+                { fileName: "doc.pdf", filePath: "template/1/a3f2c1b4/doc.pdf", fileSize: 200 },
+              ],
+            },
+            {
+              content: "world",
+              attachments: [{ fileName: "vid.mp4", filePath: "template/1/vid.mp4", fileSize: 300 }],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const result = collectFilePathsFromReactFlowData(data);
+
+    expect(result).toEqual([
+      "template/1/img.png",
+      "template/1/a3f2c1b4/doc.pdf",
+      "template/1/vid.mp4",
+    ]);
+  });
+
+  test("CombinationSendMessageノードから全添付ファイルパスを収集する", () => {
+    const data = makeReactFlowData([
+      {
+        type: "CombinationSendMessage",
+        data: {
+          entries: [
+            {
+              channelName: "general",
+              messages: [
+                {
+                  content: "hi",
+                  attachments: [
+                    { fileName: "img.png", filePath: "template/1/img.png", fileSize: 100 },
+                    { fileName: "doc.pdf", filePath: "template/1/doc.pdf", fileSize: 200 },
+                  ],
+                },
+              ],
+            },
+            {
+              channelName: "staff",
+              messages: [
+                {
+                  content: "yo",
+                  attachments: [
+                    { fileName: "vid.mp4", filePath: "template/1/vid.mp4", fileSize: 300 },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const result = collectFilePathsFromReactFlowData(data);
+
+    expect(result).toEqual(["template/1/img.png", "template/1/doc.pdf", "template/1/vid.mp4"]);
+  });
+
+  test("添付ファイルを持たないノードは無視される", () => {
+    const data = makeReactFlowData([{ type: "CreateRole", data: { title: "GM" } }]);
+
+    const result = collectFilePathsFromReactFlowData(data);
+
+    expect(result).toEqual([]);
+  });
+
+  test("複数ノード混在時に全ファイルパスを収集する", () => {
+    const data = makeReactFlowData([
+      {
+        type: "SendMessage",
+        data: {
+          messages: [
+            {
+              content: "a",
+              attachments: [{ fileName: "a.png", filePath: "template/1/a.png", fileSize: 100 }],
+            },
+          ],
+        },
+      },
+      { type: "CreateRole", data: { title: "GM" } },
+      {
+        type: "CombinationSendMessage",
+        data: {
+          entries: [
+            {
+              channelName: "ch",
+              messages: [
+                {
+                  content: "b",
+                  attachments: [{ fileName: "b.png", filePath: "template/1/b.png", fileSize: 200 }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const result = collectFilePathsFromReactFlowData(data);
+
+    expect(result).toEqual(["template/1/a.png", "template/1/b.png"]);
+  });
+
+  test("同一パスの重複が含まれる場合もそのまま返す（重複排除は呼び出し元の責務）", () => {
+    const data = makeReactFlowData([
+      {
+        type: "SendMessage",
+        data: {
+          messages: [
+            {
+              content: "a",
+              attachments: [{ fileName: "img.png", filePath: "template/1/img.png", fileSize: 100 }],
+            },
+            {
+              content: "b",
+              attachments: [{ fileName: "img.png", filePath: "template/1/img.png", fileSize: 100 }],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const result = collectFilePathsFromReactFlowData(data);
+
+    expect(result).toEqual(["template/1/img.png", "template/1/img.png"]);
   });
 });
 

--- a/frontend/src/fileSystem.ts
+++ b/frontend/src/fileSystem.ts
@@ -13,6 +13,41 @@ type Attachment = { filePath: string };
 type MessageWithAttachments = { attachments: Attachment[] };
 type EntryWithMessages = { messages: MessageWithAttachments[] };
 
+const computeSHA256 = async (data: Blob): Promise<string> => {
+  const buffer = await data.arrayBuffer();
+  const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
+  const hashArray = new Uint8Array(hashBuffer);
+  return Array.from(hashArray, (b) => b.toString(16).padStart(2, "0")).join("");
+};
+
+export function collectFilePathsFromReactFlowData(reactFlowData: ReactFlowData): string[] {
+  const filePaths: string[] = [];
+  for (const node of reactFlowData.nodes) {
+    if (node.type === "SendMessage" && Array.isArray(node.data?.messages)) {
+      for (const msg of node.data.messages as MessageWithAttachments[]) {
+        if (Array.isArray(msg.attachments)) {
+          for (const a of msg.attachments) {
+            filePaths.push(a.filePath);
+          }
+        }
+      }
+    } else if (node.type === "CombinationSendMessage" && Array.isArray(node.data?.entries)) {
+      for (const entry of node.data.entries as EntryWithMessages[]) {
+        if (Array.isArray(entry.messages)) {
+          for (const msg of entry.messages) {
+            if (Array.isArray(msg.attachments)) {
+              for (const a of msg.attachments) {
+                filePaths.push(a.filePath);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return filePaths;
+}
+
 export function convertFilePathsInReactFlowData(
   reactFlowData: ReactFlowData,
   replacer: (filePath: string) => string,
@@ -72,11 +107,36 @@ export class FileSystem {
     }
 
     const templateData = template.export();
+
+    // Collect all file paths referenced in reactFlowData
+    const allFilePaths = collectFilePathsFromReactFlowData(templateData.reactFlowData);
+    // Deduplicate and sort by path length ascending (shorter = preferred canonical path)
+    const uniquePaths = [...new Set(allFilePaths)].sort((a, b) => a.length - b.length);
+
+    // Build content-hash → canonical path and path → canonical path maps
+    const hashToCanonical = new Map<string, string>();
+    const pathToCanonical = new Map<string, string>();
+    for (const filePath of uniquePaths) {
+      let file: File;
+      try {
+        file = await this.readFile(filePath);
+      } catch {
+        continue;
+      }
+      const hash = await computeSHA256(file);
+      if (!hashToCanonical.has(hash)) {
+        hashToCanonical.set(hash, filePath);
+      }
+      pathToCanonical.set(filePath, hashToCanonical.get(hash)!);
+    }
+
+    // Convert template data: deduplicate paths, then rewrite template/{id}/ → files/
     const convertedTemplateData = {
       ...templateData,
-      reactFlowData: convertFilePathsInReactFlowData(templateData.reactFlowData, (filePath) =>
-        filePath.replace(`template/${templateId}/`, "files/"),
-      ),
+      reactFlowData: convertFilePathsInReactFlowData(templateData.reactFlowData, (filePath) => {
+        const canonical = pathToCanonical.get(filePath) ?? filePath;
+        return canonical.replace(`template/${templateId}/`, "files/");
+      }),
     };
 
     const zipFileWriter = new BlobWriter();
@@ -84,45 +144,14 @@ export class FileSystem {
 
     await zipWriter.add("template.json", new TextReader(JSON.stringify(convertedTemplateData)));
 
-    const root = await navigator.storage.getDirectory();
-
-    const addFile = async (handle: FileSystemHandle) => {
-      const segments = await root.resolve(handle);
-      if (!segments) {
-        throw new Error("ファイルのパス解決に失敗しました");
-      }
-      // segments: ["template", "{id}", ...rest] → ZIP path: "files/" + rest
-      const zipPath = "files/" + segments.slice(2).join("/");
-      const blob = await (handle as FileSystemFileHandle).getFile();
-      await zipWriter.add(zipPath, new BlobReader(blob));
-    };
-
-    const walkAndAddFiles = async (dir: FileSystemDirectoryHandle) => {
-      for await (const handle of dir.values()) {
-        if (handle.kind === "file") {
-          await addFile(handle);
-          continue;
-        }
-        await walkAndAddFiles(handle as FileSystemDirectoryHandle);
-      }
-    };
-
-    let dir: FileSystemDirectoryHandle;
-    try {
-      // ディレクトリを1つずつ取得しないとNotAllowedErrorになるブラウザがある
-      const td = await root.getDirectoryHandle("template");
-      dir = await td.getDirectoryHandle(`${templateId}`);
-    } catch (e) {
-      if (e instanceof DOMException && e.name === "NotFoundError") {
-        // No files to add
-        await zipWriter.close();
-        return zipFileWriter.getData();
-      }
-      console.error("Failed to get template directory:", e);
-      throw e;
+    // Add only canonical path files (skip duplicates)
+    for (const [filePath, canonical] of pathToCanonical) {
+      if (filePath !== canonical) continue;
+      const file = await this.readFile(filePath);
+      const zipPath = filePath.replace(`template/${templateId}/`, "files/");
+      await zipWriter.add(zipPath, new BlobReader(file));
     }
 
-    await walkAndAddFiles(dir);
     await zipWriter.close();
     return zipFileWriter.getData();
   }


### PR DESCRIPTION
## 概要

テンプレートのエクスポート ZIP に、同一内容のファイルが複数パスで重複して含まれる問題を修正する。エクスポート後の ZIP は各ファイルが一度だけ含まれることが保証される。

## 背景・意思決定

PR #114 で `saveFileToOPFS` に SHA-256 ベースの重複排除を追加したが、以下のケースで OPFS 上に同一内容が複数パスで保存されたままになっていた：

- **旧ロジックで作成されたテンプレート**: `template/5/photo.jpg` と `template/5/a1b2c3d4/photo.jpg` のように同名ファイルがランダムサブディレクトリに重複保存されていたもの
- **レアケース**: ファイルの追加・削除の順序によって `saveFileToOPFS` のハッシュ比較をすり抜けて保存された重複

旧 `exportTemplate` は OPFS ディレクトリを全走査していたため、OPFS 上の重複がそのまま ZIP に含まれていた。

新実装では「OPFS ディレクトリを全走査」から「`reactFlowData` で参照されているパスのみを対象にコンテンツハッシュで重複排除」に切り替えた。参照されていない孤立ファイルも ZIP に含まれなくなり、エクスポートの精度が向上する。

ハッシュが同一の複数パスがある場合、パス長の短いもの（ベースパス）を正規パスとして選択し、`template.json` 内の `filePath` も正規パスに統一して書き出す。

## 変更内容

- `reactFlowData` から参照ファイルパスを収集する `collectFilePathsFromReactFlowData` を追加
- `exportTemplate` がコンテンツハッシュベースの重複排除を行い、正規パスのファイルのみを ZIP に格納するよう変更
- `template.json` 内の重複パス参照が正規パスに統一されてエクスポートされる

## 確認手順

1. PR #114 以前に作成したテンプレート（`template/{id}/photo.jpg` と `template/{id}/xxxx/photo.jpg` が両方存在するもの）をエクスポート
2. ZIP を解凍し、`files/` 配下に同一内容のファイルが1つだけ含まれることを確認
3. エクスポートした ZIP を再インポートし、メッセージノードの添付ファイルが正しく表示されることを確認