### PR TITLE
セッション実行中に数値フラグを増減できるカウンターノードを追加

### DIFF
--- a/frontend/src/components/Node/base/base-schema.ts
+++ b/frontend/src/components/Node/base/base-schema.ts
@@ -34,6 +34,7 @@ export const NODE_TYPE_WIDTHS: Record<string, NodeWidth> = {
   SelectBranch: NODE_WIDTHS.md,
   ShuffleAssign: NODE_WIDTHS.lg,
   RandomSelect: NODE_WIDTHS.md,
+  Counter: NODE_WIDTHS.md,
 } as const;
 
 // Comment node default dimensions

--- a/frontend/src/components/Node/base/node-wrapper.tsx
+++ b/frontend/src/components/Node/base/node-wrapper.tsx
@@ -8,6 +8,7 @@ import {
   ChangeChannelPermissionNode,
   CommentNode,
   ConditionalBranchNode,
+  CounterNode,
   CreateCategoryNode,
   CreateChannelNode,
   CreateRoleNode,
@@ -105,6 +106,10 @@ export function createNodeTypes(mode: "edit" | "execute" = "edit"): NodeTypes {
     <RandomSelectNode {...props} mode={mode} />
   );
 
+  const CounterWithMode: ComponentType<NodeProps<any>> = (props) => (
+    <CounterNode {...props} mode={mode} />
+  );
+
   return {
     CreateCategory: CreateCategoryWithMode,
     CreateRole: CreateRoleWithMode,
@@ -126,5 +131,6 @@ export function createNodeTypes(mode: "edit" | "execute" = "edit"): NodeTypes {
     SelectBranch: SelectBranchWithMode,
     ShuffleAssign: ShuffleAssignWithMode,
     RandomSelect: RandomSelectWithMode,
+    Counter: CounterWithMode,
   } as NodeTypes;
 }

--- a/frontend/src/components/Node/index.ts
+++ b/frontend/src/components/Node/index.ts
@@ -23,4 +23,5 @@ export {
   SetGameFlagDataSchema,
   ShuffleAssignDataSchema,
   RandomSelectDataSchema,
+  CounterDataSchema,
 } from "./nodes";

--- a/frontend/src/components/Node/nodes/CounterNode.tsx
+++ b/frontend/src/components/Node/nodes/CounterNode.tsx
@@ -1,0 +1,161 @@
+import { Position, type Node, type NodeProps } from "@xyflow/react";
+import { useLiveQuery } from "dexie-react-hooks";
+import z from "zod";
+
+import { GameSession } from "@/db";
+import { useTemplateEditorStore } from "@/stores/templateEditorStore";
+import { useToast } from "@/toast/ToastProvider";
+
+import {
+  BaseHandle,
+  BaseNode,
+  BaseNodeContent,
+  BaseNodeHeader,
+  BaseNodeHeaderTitle,
+  EditableTitle,
+  BaseNodeDataSchema,
+  NODE_TYPE_WIDTHS,
+} from "../base";
+import { useNodeExecutionOptional } from "../contexts";
+
+export const DataSchema = BaseNodeDataSchema.extend({
+  title: z.string().default("カウンター"),
+  flagKey: z.string().trim(),
+  step: z.number().int().positive().default(1),
+});
+
+type CounterNodeData = Node<z.infer<typeof DataSchema>, "Counter">;
+
+export const CounterNode = ({
+  id,
+  data,
+  mode = "edit",
+}: NodeProps<CounterNodeData> & { mode?: "edit" | "execute" }) => {
+  const updateNodeData = useTemplateEditorStore((state) => state.updateNodeData);
+  const executionContext = useNodeExecutionOptional();
+  const { addToast } = useToast();
+
+  const sessionId = executionContext?.sessionId;
+
+  const currentValue = useLiveQuery(async () => {
+    if (!sessionId) return 0;
+    const session = await GameSession.getById(sessionId);
+    const flags = session?.getParsedGameFlags() ?? {};
+    return Number(flags[data.flagKey]) || 0;
+  }, [sessionId, data.flagKey]);
+
+  const handleTitleChange = (newTitle: string) => {
+    updateNodeData(id, { title: newTitle });
+  };
+
+  const handleFlagKeyChange = (newValue: string) => {
+    updateNodeData(id, { flagKey: newValue });
+  };
+
+  const handleStepChange = (newValue: number) => {
+    if (newValue >= 1) {
+      updateNodeData(id, { step: newValue });
+    }
+  };
+
+  const handleCounter = async (delta: number) => {
+    if (!executionContext) {
+      addToast({ message: "実行コンテキストがありません", status: "error" });
+      return;
+    }
+
+    const key = data.flagKey.trim();
+    if (key === "") {
+      addToast({ message: "フラグ名を入力してください", status: "warning" });
+      return;
+    }
+
+    try {
+      const session = await GameSession.getById(executionContext.sessionId);
+      if (!session) {
+        addToast({ message: "セッションが見つかりません", status: "error" });
+        return;
+      }
+
+      const currentFlags = session.getParsedGameFlags();
+      const current = Number(currentFlags[key]) || 0;
+      await session.update({ gameFlags: { ...currentFlags, [key]: String(current + delta) } });
+    } catch {
+      addToast({ message: "カウンターの更新に失敗しました", status: "error" });
+    }
+  };
+
+  const isExecuteMode = mode === "execute";
+  const displayValue = currentValue ?? 0;
+  const step = data.step ?? 1;
+
+  return (
+    <BaseNode width={NODE_TYPE_WIDTHS.Counter} className="bg-base-300">
+      <BaseNodeHeader>
+        {isExecuteMode ? (
+          <BaseNodeHeaderTitle>{data.title || "カウンター"}</BaseNodeHeaderTitle>
+        ) : (
+          <EditableTitle
+            title={data.title}
+            defaultTitle="カウンター"
+            onTitleChange={handleTitleChange}
+          />
+        )}
+      </BaseNodeHeader>
+      <BaseNodeContent>
+        {!isExecuteMode && (
+          <>
+            <label className="form-control w-full">
+              <div className="label">
+                <span className="label-text">フラグ名</span>
+              </div>
+              <input
+                type="text"
+                className="nodrag input input-bordered w-full"
+                value={data.flagKey}
+                onChange={(evt) => handleFlagKeyChange(evt.target.value)}
+                placeholder="例: ラウンド数, ライフ"
+              />
+            </label>
+            <label className="form-control w-full">
+              <div className="label">
+                <span className="label-text">増減量</span>
+              </div>
+              <input
+                type="number"
+                className="nodrag input input-bordered w-full"
+                value={step}
+                min={1}
+                onChange={(evt) => handleStepChange(Number(evt.target.value))}
+              />
+            </label>
+          </>
+        )}
+        {isExecuteMode && (
+          <div className="flex flex-col items-center gap-3 py-2">
+            <div className="text-xs text-base-content/60">{data.flagKey || "(フラグ未設定)"}</div>
+            <div className="text-4xl font-bold tabular-nums">{displayValue}</div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="nodrag btn btn-outline btn-sm"
+                onClick={() => handleCounter(-step)}
+              >
+                -{step}
+              </button>
+              <button
+                type="button"
+                className="nodrag btn btn-outline btn-sm"
+                onClick={() => handleCounter(step)}
+              >
+                +{step}
+              </button>
+            </div>
+          </div>
+        )}
+      </BaseNodeContent>
+      <BaseHandle id="target-1" type="target" position={Position.Left} />
+      <BaseHandle id="source-1" type="source" position={Position.Right} />
+    </BaseNode>
+  );
+};

--- a/frontend/src/components/Node/nodes/index.ts
+++ b/frontend/src/components/Node/nodes/index.ts
@@ -52,3 +52,5 @@ export { SelectBranchNode, DataSchema as SelectBranchDataSchema } from "./Select
 export { ShuffleAssignNode, DataSchema as ShuffleAssignDataSchema } from "./ShuffleAssignNode";
 
 export { RandomSelectNode, DataSchema as RandomSelectDataSchema } from "./RandomSelectNode";
+
+export { CounterNode, DataSchema as CounterDataSchema } from "./CounterNode";

--- a/frontend/src/components/Node/utils/collectResources.test.ts
+++ b/frontend/src/components/Node/utils/collectResources.test.ts
@@ -260,6 +260,46 @@ describe("collectResourcesBeforeNode", () => {
     });
   });
 
+  describe("gameFlags - CounterNode", () => {
+    it("CounterNode から flagKey を収集する（values は空配列）", () => {
+      const nodes = [
+        makeNode("counter-1", "Counter", { flagKey: "ラウンド数", step: 1 }),
+        makeNode("target", "ConditionalBranch", {}),
+      ];
+      const edges = [makeEdge("counter-1", "target")];
+
+      const result = collectResourcesBeforeNode("target", nodes, edges);
+
+      expect(result.gameFlags).toEqual([
+        { key: "ラウンド数", values: [], sourceNodeId: "counter-1" },
+      ]);
+    });
+
+    it("flagKey が空文字の場合はスキップする", () => {
+      const nodes = [
+        makeNode("counter-1", "Counter", { flagKey: "", step: 1 }),
+        makeNode("target", "ConditionalBranch", {}),
+      ];
+      const edges = [makeEdge("counter-1", "target")];
+
+      const result = collectResourcesBeforeNode("target", nodes, edges);
+
+      expect(result.gameFlags).toEqual([]);
+    });
+
+    it("flagKey がスペースのみの場合はスキップする", () => {
+      const nodes = [
+        makeNode("counter-1", "Counter", { flagKey: "   ", step: 1 }),
+        makeNode("target", "ConditionalBranch", {}),
+      ];
+      const edges = [makeEdge("counter-1", "target")];
+
+      const result = collectResourcesBeforeNode("target", nodes, edges);
+
+      expect(result.gameFlags).toEqual([]);
+    });
+  });
+
   describe("混在ケース", () => {
     it("3種のノードが混在する場合にすべて収集する", () => {
       const nodes = [
@@ -319,6 +359,46 @@ describe("collectResourcesBeforeNode", () => {
 
       expect(result.gameFlags).toHaveLength(4);
       expect(result.gameFlags.map((f) => f.key)).toEqual(["phase", "team", "role_Alice", "犯人"]);
+    });
+
+    it("5種のノードが混在する場合にすべて収集する（CounterNode を含む）", () => {
+      const nodes = [
+        makeNode("flag-1", "SetGameFlag", { flagKey: "phase", flagValue: "start" }),
+        makeNode("branch-1", "SelectBranch", {
+          flagName: "team",
+          options: [{ id: "1", label: "red" }],
+        }),
+        makeNode("shuffle-1", "ShuffleAssign", {
+          resultFlagPrefix: "role",
+          targets: ["Alice"],
+          items: ["Detective"],
+        }),
+        makeNode("random-1", "RandomSelect", {
+          resultFlagKey: "犯人",
+          items: ["Alice", "Bob"],
+        }),
+        makeNode("counter-1", "Counter", { flagKey: "ラウンド数", step: 1 }),
+        makeNode("target", "ConditionalBranch", {}),
+      ];
+      const edges = [
+        makeEdge("flag-1", "target"),
+        makeEdge("branch-1", "target"),
+        makeEdge("shuffle-1", "target"),
+        makeEdge("random-1", "target"),
+        makeEdge("counter-1", "target"),
+      ];
+
+      const result = collectResourcesBeforeNode("target", nodes, edges);
+
+      expect(result.gameFlags).toHaveLength(5);
+      expect(result.gameFlags.map((f) => f.key)).toEqual([
+        "phase",
+        "team",
+        "role_Alice",
+        "犯人",
+        "ラウンド数",
+      ]);
+      expect(result.gameFlags.find((f) => f.key === "ラウンド数")?.values).toEqual([]);
     });
   });
 

--- a/frontend/src/components/Node/utils/collectResources.ts
+++ b/frontend/src/components/Node/utils/collectResources.ts
@@ -107,6 +107,15 @@ export function collectResourcesBeforeNode(
           sourceNodeId: node.id,
         });
       }
+    } else if (node.type === "Counter") {
+      const data = node.data as { flagKey: string };
+      if (data.flagKey.trim()) {
+        resources.gameFlags.push({
+          key: data.flagKey.trim(),
+          values: [],
+          sourceNodeId: node.id,
+        });
+      }
     }
   }
 

--- a/frontend/src/components/TemplateEditor.tsx
+++ b/frontend/src/components/TemplateEditor.tsx
@@ -89,6 +89,7 @@ const NODE_CATEGORIES = [
     category: "ゲーム管理",
     nodes: [
       { type: "SetGameFlag", label: "ゲームフラグを設定する" },
+      { type: "Counter", label: "カウンター" },
       { type: "ConditionalBranch", label: "条件で分岐する" },
       { type: "SelectBranch", label: "選択肢から分岐する" },
       { type: "RecordCombination", label: "組み合わせを記録する" },

--- a/frontend/src/stores/templateEditorStore.ts
+++ b/frontend/src/stores/templateEditorStore.ts
@@ -19,6 +19,7 @@ import {
   type CombinationSendMessageDataSchema,
   type CommentDataSchema,
   type ConditionalBranchDataSchema,
+  type CounterDataSchema,
   type CreateCategoryDataSchema,
   type CreateChannelDataSchema,
   type CreateRoleDataSchema,
@@ -60,6 +61,7 @@ export type SendMessageNodeData = z.infer<typeof SendMessageDataSchema>;
 export type SetGameFlagNodeData = z.infer<typeof SetGameFlagDataSchema>;
 export type ShuffleAssignNodeData = z.infer<typeof ShuffleAssignDataSchema>;
 export type RandomSelectNodeData = z.infer<typeof RandomSelectDataSchema>;
+export type CounterNodeData = z.infer<typeof CounterDataSchema>;
 
 export type FlowNode =
   | Node<AddRoleToRoleMembersNodeData, "AddRoleToRoleMembers">
@@ -81,7 +83,8 @@ export type FlowNode =
   | Node<SendMessageNodeData, "SendMessage">
   | Node<SetGameFlagNodeData, "SetGameFlag">
   | Node<ShuffleAssignNodeData, "ShuffleAssign">
-  | Node<RandomSelectNodeData, "RandomSelect">;
+  | Node<RandomSelectNodeData, "RandomSelect">
+  | Node<CounterNodeData, "Counter">;
 
 // Helper function: Generate next ID with sequential numbering
 const generateNextId = (nodes: FlowNode[], nodeType: string): string => {
@@ -131,6 +134,7 @@ interface TemplateEditorActions {
       | SetGameFlagNodeData
       | ShuffleAssignNodeData
       | RandomSelectNodeData
+      | CounterNodeData
     >,
   ) => void;
   addNode: (
@@ -154,7 +158,8 @@ interface TemplateEditorActions {
       | "SendMessage"
       | "SetGameFlag"
       | "ShuffleAssign"
-      | "RandomSelect",
+      | "RandomSelect"
+      | "Counter",
     position: { x: number; y: number },
   ) => void;
   expandBlueprint: (nodeId: string) => void;
@@ -441,6 +446,13 @@ export const useTemplateEditorStore = create<TemplateEditorStore>((set, get) => 
           items: [""],
           resultFlagKey: "",
         },
+      };
+    } else if (type === "Counter") {
+      newNode = {
+        id,
+        type,
+        position,
+        data: { title: "カウンター", flagKey: "", step: 1 },
       };
     } else {
       newNode = {


### PR DESCRIPTION
## 概要

ゲームセッション実行中に、ライフポイントやラウンド数などの数値をボタン操作で増減できる「カウンター」ノードを追加する。

## 背景・意思決定

- 既存の SetGameFlagNode は値を1回だけ設定するユースケース向けで、繰り返し増減する数値管理には不向き
- KanbanNode と同様に `executedAt` による完了管理を持たず、何度でも操作できる設計とした
- カウンター値は GameFlag（`Record<string, string>`）に文字列として保存し、既存のフラグ基盤を再利用する
- フラグが未設定の場合は 0 として扱うことで、初期化なしで利用可能にした
- `useLiveQuery` でカウンター値をリアルタイム購読することで、同一セッション内の複数ノードから同じフラグを参照・更新しても即座に画面に反映される

## 変更内容

- テンプレートエディタの「ゲーム管理」カテゴリに「カウンター」ノードが追加される
- Edit モードでフラグ名と増減量（デフォルト 1）を設定できる
- Execute モードで現在値を大きく表示し、`-N` / `+N` ボタンで即座に値を更新できる
- ConditionalBranchNode など他ノードのリソース収集において、CounterNode が参照するフラグキーが候補として表示されるようになる

## 確認手順

1. テンプレートエディタを開き、「ゲーム管理」カテゴリから「カウンター」をキャンバスに配置
2. Edit モードでフラグ名（例: `ラウンド数`）と増減量（例: `2`）を入力
3. セッションを開始して Execute モードに切り替え
4. `-2` / `+2` ボタンを押して値が増減することを確認
5. セッションリソースパネルで対応するゲームフラグの値が更新されることを確認
6. ConditionalBranchNode を追加し、フラグ名の候補に `ラウンド数` が表示されることを確認