### PR TITLE
CreateChannelNode でチャンネルの並べ替えができるようになった

### DIFF
--- a/frontend/src/components/Node/nodes/CreateChannelNode.tsx
+++ b/frontend/src/components/Node/nodes/CreateChannelNode.tsx
@@ -1,5 +1,6 @@
 import { Position, type Node, type NodeProps } from "@xyflow/react";
 import { useEffect, useState } from "react";
+import { HiChevronDown, HiChevronUp } from "react-icons/hi";
 import z from "zod";
 
 import { ApiClient } from "@/api";
@@ -85,6 +86,20 @@ export const CreateChannelNode = ({
   const handleRemoveChannel = (index: number) => {
     const updatedChannels = data.channels.filter((_, i) => i !== index);
     updateNodeData(id, { channels: updatedChannels });
+  };
+
+  const handleMoveChannelUp = (index: number) => {
+    if (index === 0) return;
+    const updated = [...data.channels];
+    [updated[index - 1], updated[index]] = [updated[index], updated[index - 1]];
+    updateNodeData(id, { channels: updated });
+  };
+
+  const handleMoveChannelDown = (index: number) => {
+    if (index === data.channels.length - 1) return;
+    const updated = [...data.channels];
+    [updated[index], updated[index + 1]] = [updated[index + 1], updated[index]];
+    updateNodeData(id, { channels: updated });
   };
 
   const handleAddRolePermission = (channelIndex: number) => {
@@ -270,14 +285,34 @@ export const CreateChannelNode = ({
                   <span className="text-xs">ボイス</span>
                 </label>
                 {!isExecuteMode && (
-                  <button
-                    type="button"
-                    className="nodrag btn btn-ghost btn-sm"
-                    onClick={() => handleRemoveChannel(channelIndex)}
-                    disabled={isLoading || isExecuted}
-                  >
-                    削除
-                  </button>
+                  <>
+                    <button
+                      type="button"
+                      className="nodrag btn btn-ghost btn-sm btn-square"
+                      onClick={() => handleMoveChannelUp(channelIndex)}
+                      disabled={isLoading || isExecuted || channelIndex === 0}
+                    >
+                      <HiChevronUp />
+                    </button>
+                    <button
+                      type="button"
+                      className="nodrag btn btn-ghost btn-sm btn-square"
+                      onClick={() => handleMoveChannelDown(channelIndex)}
+                      disabled={
+                        isLoading || isExecuted || channelIndex === data.channels.length - 1
+                      }
+                    >
+                      <HiChevronDown />
+                    </button>
+                    <button
+                      type="button"
+                      className="nodrag btn btn-ghost btn-sm"
+                      onClick={() => handleRemoveChannel(channelIndex)}
+                      disabled={isLoading || isExecuted}
+                    >
+                      削除
+                    </button>
+                  </>
                 )}
               </div>
 


### PR DESCRIPTION
## 概要

CreateChannelNode で定義した複数チャンネルを、上下ボタンで並べ替えられるようになった。チャンネルは上から順に作成されるため、作成順を後から調整できる。

## 背景・意思決定

既存の ConditionalBranchNode が同様の「上下スワップ」パターン（`handleMoveUp` / `handleMoveDown`）を実装済みであるため、同じ設計を踏襲した。独自の DnD を導入する必要はなく、シンプルな配列スワップで十分。

## 変更内容

- 各チャンネルカードのヘッダー行に ↑ / ↓ ボタンを追加（editモード時のみ表示）
- 先頭チャンネルの ↑ ボタン、末尾チャンネルの ↓ ボタンは disabled

## 確認手順

1. テンプレートエディターで CreateChannelNode を開く
2. チャンネルを複数追加する
3. ↑ / ↓ ボタンでチャンネルの順番が入れ替わることを確認
4. 先頭の ↑ と末尾の ↓ が disabled になっていることを確認