### PR TITLE
ロールメンバー取得失敗時に「Server Members Intent を有効にしてください」と案内する

### DIFF
--- a/backend/src/discord.ts
+++ b/backend/src/discord.ts
@@ -1,4 +1,4 @@
-import { REST, type RawFile } from "@discordjs/rest";
+import { DiscordAPIError, REST, type RawFile } from "@discordjs/rest";
 import {
   ChannelType,
   OverwriteType,
@@ -229,9 +229,19 @@ export async function addRoleToRoleMembers(token: string, data: AddRoleToRoleMem
     if (after) {
       query.append("after", after);
     }
-    const members = (await rest.get(Routes.guildMembers(data.guildId), {
-      query,
-    })) as RESTGetAPIGuildMemberResult[];
+    let members: RESTGetAPIGuildMemberResult[];
+    try {
+      members = (await rest.get(Routes.guildMembers(data.guildId), {
+        query,
+      })) as RESTGetAPIGuildMemberResult[];
+    } catch (e) {
+      if (e instanceof DiscordAPIError && e.code === 50001) {
+        throw new Error(
+          "ギルドメンバーの取得に失敗しました。Discord Developer Portal で「Server Members Intent」を有効にしてください",
+        );
+      }
+      throw e;
+    }
     if (members.length === 0) break;
     for (const member of members) {
       if (member.roles.includes(data.memberRoleId)) {


### PR DESCRIPTION
## 概要

`AddRoleToRoleMembersNode` でロールメンバーへのロール付与が失敗した際、「Missing Access」という無意味なエラーではなく、「Discord Developer Portal で Server Members Intent を有効にしてください」という具体的な対処法をユーザーに伝えるようにする。

## 背景・意思決定

ギルドメンバー一覧取得 (`GET /guilds/{id}/members`) は Discord API の仕様上、**GUILD_MEMBERS Privileged Intent** が有効でないと `DiscordAPIError[50001] Missing Access` が返る。代替 API（Search Guild Members など）ではロールによるフィルタリングができないため、Intent 有効化が唯一の解決策となる。

エラーハンドリングはバックエンド（`discord.ts`）で行い、通常の `Error` として re-throw することで既存のエラー伝播フロー（`index.ts:onError` → フロントエンド toast）をそのまま活用している。

## 変更内容

- DiscordAPIError コード 50001 を個別にキャッチし、対処法を含む日本語メッセージに変換
- それ以外のエラーはそのまま re-throw して既存の挙動を維持

## 確認手順

1. Server Members Intent が無効なボットトークンで `AddRoleToRoleMembersNode` を実行
2. toast に「ギルドメンバーの取得に失敗しました。Discord Developer Portal で「Server Members Intent」を有効にしてください」と表示されることを確認