### PR TITLE
fix: Discordチャンネル名の大文字小文字によるエラーを修正

### DIFF
--- a/backend/src/discord.ts
+++ b/backend/src/discord.ts
@@ -139,7 +139,7 @@ export async function createCategory(token: string, data: CreateCategoryData) {
   const category = (await rest.post(Routes.guildChannels(data.guildId), {
     body: {
       type: ChannelType.GuildCategory,
-      name: data.name,
+      name: data.name.toLowerCase(),
       permission_overwrites: [
         {
           id: data.guildId,
@@ -160,7 +160,7 @@ export async function createChannel(token: string, data: CreateChannelData) {
   const channel = (await rest.post(Routes.guildChannels(data.guildId), {
     body: {
       type: data.type === "text" ? ChannelType.GuildText : ChannelType.GuildVoice,
-      name: data.name,
+      name: data.name.toLowerCase(),
       parent_id: data.parentCategoryId,
       permission_overwrites: [
         {

--- a/frontend/src/components/Node/nodes/ChangeChannelPermissionNode.tsx
+++ b/frontend/src/components/Node/nodes/ChangeChannelPermissionNode.tsx
@@ -102,7 +102,9 @@ export const ChangeChannelPermissionNode = ({
       return;
     }
 
-    const channel = channels.find((c) => c.name === data.channelName.trim());
+    const channel = channels.find(
+      (c) => c.name.toLowerCase() === data.channelName.trim().toLowerCase(),
+    );
     if (!channel) {
       addToast({
         message: `チャンネル「${data.channelName}」が見つかりません`,

--- a/frontend/src/components/Node/nodes/CombinationSendMessageNode.tsx
+++ b/frontend/src/components/Node/nodes/CombinationSendMessageNode.tsx
@@ -312,7 +312,7 @@ export const CombinationSendMessageNode = ({
       const channelName = entry.channelName.trim();
       if (!channelName) continue;
 
-      const channel = channels.find((c) => c.name === channelName);
+      const channel = channels.find((c) => c.name.toLowerCase() === channelName.toLowerCase());
       if (channel) {
         resolvedEntries.push({ channelId: channel.id, messages: entry.messages });
       } else {

--- a/frontend/src/components/Node/nodes/DeleteChannelNode.tsx
+++ b/frontend/src/components/Node/nodes/DeleteChannelNode.tsx
@@ -80,7 +80,7 @@ export const DeleteChannelNode = ({
     const targetChannels: ChannelData[] = [];
 
     for (const name of validNames) {
-      const found = sessionChannels.find((ch) => ch.name === name);
+      const found = sessionChannels.find((ch) => ch.name.toLowerCase() === name.toLowerCase());
       if (!found) {
         notFoundNames.push(name);
       } else {

--- a/frontend/src/components/Node/nodes/SendMessageNode.tsx
+++ b/frontend/src/components/Node/nodes/SendMessageNode.tsx
@@ -330,7 +330,7 @@ export const SendMessageNode = ({
     const notFoundChannels: string[] = [];
 
     for (const channelName of resolvedChannelNames) {
-      const channel = channels.find((c) => c.name === channelName);
+      const channel = channels.find((c) => c.name.toLowerCase() === channelName.toLowerCase());
       if (channel) {
         targetChannels.push(channel);
       } else {


### PR DESCRIPTION
## Summary

- Discordはチャンネル名を小文字に正規化するが、アプリ側でそれを考慮していなかったため、大文字を含むチャンネル名（例: `VC-1`）で操作するとチャンネルが見つからないエラーが発生していた
- backend の `createCategory` / `createChannel` でDiscord APIへ送信する前に `toLowerCase()` を適用
- frontend の各ノードでのチャンネル名検索を case-insensitive な比較に変更（表示は元のケーシングを保持）

## Changes

| ファイル | 変更内容 |
|---|---|
| `backend/src/discord.ts` | `createCategory` / `createChannel` で `data.name.toLowerCase()` を適用 |
| `DeleteChannelNode.tsx` | `ch.name.toLowerCase() === name.toLowerCase()` |
| `ChangeChannelPermissionNode.tsx` | `c.name.toLowerCase() === data.channelName.trim().toLowerCase()` |
| `SendMessageNode.tsx` | `c.name.toLowerCase() === channelName.toLowerCase()` |
| `CombinationSendMessageNode.tsx` | `c.name.toLowerCase() === channelName.toLowerCase()` |

## Test plan

- [ ] 大文字を含むチャンネル名（例: `Test-Channel`）でワークフローを実行し、エラーなく作成・送信・削除ができること
- [ ] 既存テストが全通過すること (`bun run --bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)