### PR TITLE
deps: migrate typescript 5.9.3 → 6.0.2

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -22,9 +22,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "4.20251212.0",
-    "@types/bun": "1.3.11"
-  },
-  "peerDependencies": {
-    "typescript": "5.9.3"
+    "@types/bun": "1.3.11",
+    "typescript": "6.0.2"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "oxfmt": "0.17.0",
         "oxlint": "1.32.0",
         "oxlint-tsgolint": "0.8.6",
-        "typescript": "5.9.3",
+        "typescript": "6.0.2",
         "wrangler": "4.59.1",
       },
     },
@@ -27,9 +27,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "4.20251212.0",
         "@types/bun": "1.3.11",
-      },
-      "peerDependencies": {
-        "typescript": "5.9.3",
+        "typescript": "6.0.2",
       },
     },
     "frontend": {
@@ -63,10 +61,8 @@
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.1",
         "fake-indexeddb": "6.2.5",
+        "typescript": "6.0.2",
         "vite": "8.0.3",
-      },
-      "peerDependencies": {
-        "typescript": "5.9.3",
       },
     },
   },
@@ -789,7 +785,7 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "undici": ["undici@6.24.1", "", {}, "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,9 +42,7 @@
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.1",
     "fake-indexeddb": "6.2.5",
+    "typescript": "6.0.2",
     "vite": "8.0.3"
-  },
-  "peerDependencies": {
-    "typescript": "5.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "oxfmt": "0.17.0",
     "oxlint": "1.32.0",
     "oxlint-tsgolint": "0.8.6",
-    "typescript": "5.9.3",
+    "typescript": "6.0.2",
     "wrangler": "4.59.1"
   }
 }


### PR DESCRIPTION
## Summary

- `typescript` を `5.9.3` → `6.0.2` にアップデート
- backend/frontend の `peerDependencies` にあった `typescript` を `devDependencies` に移動（誤配置を修正）

## Migration Notes

- `ts5to6` 自動移行ツール（`@andrewbranch/ts5to6`）を実行 → No changes needed（コード変更不要）
- 現在の tsconfig は既にモダンな設定（`moduleResolution: bundler`, `module: ESNext`, `strict: true`）で非推奨オプションの使用なし
- `import ... assert {}` 構文の使用もなし

## Test plan

- [x] `bun run --bun type-check` — 0 errors
- [x] `bun run --bun build` — ビルド成功
- [x] `bun run --bun test` — 300 tests pass
- [x] `bun run --bun format` — 0 errors
- [x] `bun run --bun lint` — 0 errors
- [x] `bun run knip` — 未使用なし

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)