### PR TITLE
chore(claude): add project-scope Claude Code config

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,32 @@
+---
+name: security-reviewer
+description: Security review for gm-assistant-bot. Checks Discord webhook signature verification, Cloudflare Workers secrets handling, Hono API security, and supply chain compliance.
+---
+
+Review the code changes for security issues specific to this project:
+
+**Discord Bot Security**
+- Verify Ed25519 signature validation is present and not bypassable for all webhook endpoints
+- Check that `DISCORD_PUBLIC_KEY` is read from env, never hardcoded
+- Confirm no Discord bot token or application ID is embedded in source
+
+**Cloudflare Workers / Secrets**
+- All secrets accessed via `c.env.*` (Hono context), never via `process.env` or hardcoded
+- No secrets logged or returned in API responses
+- `wrangler.toml` contains no secret values (only `[vars]` for non-sensitive config)
+
+**Hono API**
+- Input validation via Zod schema on all routes accepting user data
+- Error responses don't leak internal details (stack traces, file paths)
+- CORS policy is explicit, not wildcard `*` for sensitive endpoints
+
+**Supply Chain**
+- All dependencies use fixed versions (no `^` or `~`)
+- GitHub Actions pinned to full commit SHA
+- No new packages added without 7-day cooldown check
+
+**Frontend / OPFS**
+- User-provided filenames sanitized before use as OPFS paths
+- No eval or dangerouslySetInnerHTML with user-controlled content
+
+Report issues as: [CRITICAL] / [HIGH] / [MEDIUM] with file:line reference.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | { read -r f; [[ -z \"$f\" || ! \"$f\" =~ \\.(ts|tsx|js|jsx)$ ]] && exit 0; oxfmt --write \"$f\" && oxlint --fix \"$f\"; } 2>/dev/null || true",
+            "statusMessage": "Formatting..."
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "deny": [
+      "Read(**/.env*)",
+      "Edit(**/.env*)",
+      "Write(**/.env*)",
+      "Read(**/.dev.vars)",
+      "Edit(**/.dev.vars)",
+      "Write(**/.dev.vars)"
+    ]
+  },
+  "enabledPlugins": {
+    "context7@claude-plugins-official": true
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -11,11 +11,11 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/4ry96w6s7jql71336lfm31m7fwn3ri2d-bun-1.3.11",
+              "path": "/nix/store/x1l9wqqzh1b01fal435vv5gzdfn2zalp-bun-1.3.11",
               "default": true
             }
           ],
-          "store_path": "/nix/store/4ry96w6s7jql71336lfm31m7fwn3ri2d-bun-1.3.11"
+          "store_path": "/nix/store/x1l9wqqzh1b01fal435vv5gzdfn2zalp-bun-1.3.11"
         },
         "aarch64-linux": {
           "outputs": [
@@ -31,11 +31,11 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/582vfzcrgff132nbx86qbp8l3wfw7hr2-bun-1.3.11",
+              "path": "/nix/store/gsmw754waa5igi0ylmlnkdjq1x8r2y5f-bun-1.3.11",
               "default": true
             }
           ],
-          "store_path": "/nix/store/582vfzcrgff132nbx86qbp8l3wfw7hr2-bun-1.3.11"
+          "store_path": "/nix/store/gsmw754waa5igi0ylmlnkdjq1x8r2y5f-bun-1.3.11"
         },
         "x86_64-linux": {
           "outputs": [
@@ -50,8 +50,8 @@
       }
     },
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "last_modified": "2026-04-10T03:55:24Z",
-      "resolved": "github:NixOS/nixpkgs/9d29d5f667d7467f98efc31881e824fa586c927e?lastModified=1775793324"
+      "last_modified": "2026-04-27T06:11:55Z",
+      "resolved": "github:NixOS/nixpkgs/6368eda62c9775c38ef7f714b2555a741c20c72d?lastModified=1777270315"
     },
     "osv-scanner@2.3.3": {
       "last_modified": "2026-04-16T08:46:55Z",


### PR DESCRIPTION
## Summary

- **Format/lint hook**: `PostToolUse` on `Edit|Write` — runs `oxfmt --write` + `oxlint --fix` on `.ts/.tsx/.js/.jsx` files automatically, eliminating the need to run `bun run format` manually after every edit
- **Deny permissions**: blocks `Read/Edit/Write` on `.env*` and `.dev.vars` to prevent accidental exposure of Cloudflare Workers secrets
- **context7 plugin**: enables `context7@claude-plugins-official` at project scope for live library docs (React, Hono, Zod, Dexie, TanStack Router)
- **security-reviewer agent**: `.claude/agents/security-reviewer.md` with project-tailored checks — Discord Ed25519 webhook verification, Cloudflare secrets handling, Hono input validation, supply chain (fixed versions + 7-day cooldown)
- **devbox.lock**: update bun-1.3.11 nix store path

## Test plan

- [ ] Edit a `.ts` file → confirm oxfmt/oxlint hook runs silently (status: "Formatting...")
- [ ] Edit a `.json` or `.md` file → confirm hook skips (no formatting)
- [ ] Verify deny: attempt `Read(.env)` → permission denied
- [ ] context7: open `/hooks` or restart session → confirm context7 skills available
- [ ] Agent: invoke security-reviewer on a PR with code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)