### PR TITLE
Add ccweb setup script and improve environment hook logic

### DIFF
--- a/.claude/scripts/setup-ccweb.sh
+++ b/.claude/scripts/setup-ccweb.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+export PATH="/nix/var/nix/profiles/default/bin:$PATH"
+devbox global add direnv
+eval "$(devbox global shellenv)"
+direnv export bash > "$CLAUDE_ENV_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "direnv export bash > \"$CLAUDE_ENV_FILE\""
+            "command": "if [ \"$CLAUDE_CODE_REMOTE\" = \"true\" ]; then bash \"$CLAUDE_PROJECT_DIR/.claude/scripts/setup-ccweb.sh\"; else direnv export bash > \"$CLAUDE_ENV_FILE\"; fi"
           }
         ]
       }
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // empty' | { read -r f; [[ -z \"$f\" || ! \"$f\" =~ \\.(ts|tsx|js|jsx)$ ]] && exit 0; oxfmt --write \"$f\" && oxlint --fix \"$f\"; } 2>/dev/null || true",
+            "command": "jq -r '.tool_input.file_path // empty' | { read -r f; case \"$f\" in *.ts|*.tsx|*.js|*.jsx) oxfmt --write \"$f\" && oxlint --fix \"$f\";; esac; } 2>/dev/null || true",
             "statusMessage": "Formatting..."
           }
         ]


### PR DESCRIPTION
## Summary
This PR improves the Claude environment setup by adding a dedicated setup script for ccweb environments and refining the environment hook configuration to handle different deployment contexts.

## Key Changes
- **New setup script** (`.claude/scripts/setup-ccweb.sh`): Added a dedicated initialization script for ccweb environments that:
  - Sources the Nix daemon profile
  - Installs and initializes devbox globally
  - Exports the direnv environment configuration
  
- **Enhanced environment hook** in `.claude/settings.json`: Modified the environment hook to conditionally execute different setup paths:
  - Uses the new ccweb setup script when running in remote/ccweb context (`CLAUDE_CODE_REMOTE=true`)
  - Falls back to standard direnv export for local environments
  
- **Improved file formatting hook**: Refactored the TypeScript/JavaScript formatting command to use a more robust `case` statement instead of regex matching, improving reliability and readability

## Implementation Details
The conditional logic in the environment hook allows the same configuration to work across different deployment contexts without requiring separate configuration files. The ccweb setup script ensures all necessary tools (Nix, devbox, direnv) are properly initialized in remote environments where they may not be pre-configured.

https://claude.ai/code/session_01KoidioaGMuQFiQaAZzAhhT