### PR TITLE
refactor: rename type-check script to typecheck

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // empty' | { read -r f; [[ -z \"$f\" || ! \"$f\" =~ \\.(ts|tsx|js|jsx)$ ]] && exit 0; oxfmt --write \"$f\" && oxlint --fix \"$f\"; } 2>/dev/null || true",
+            "command": "jq -r '.tool_input.file_path // empty' | { read -r f; case \"$f\" in *.ts|*.tsx|*.js|*.jsx) oxfmt --write \"$f\" && oxlint --fix \"$f\";; esac; } 2>/dev/null || true",
             "statusMessage": "Formatting..."
           }
         ]

--- a/.claude/skills/update-dependencies/SKILL.md
+++ b/.claude/skills/update-dependencies/SKILL.md
@@ -70,7 +70,7 @@ Pass the list of Batched packages (identified in Step 2) to a single sub-agent. 
 - Work in a single git worktree and produce a single PR.
 - Update packages one at a time, running the following tests after each update:
   ```
-  bun run --bun test && bun run --bun type-check && bun run --bun lint && bun run knip
+  bun run --bun test && bun run --bun typecheck && bun run --bun lint && bun run knip
   ```
 - If tests pass, proceed to the next package (one commit per package).
 - If tests fail, do not create a commit for that package. Revert to the pre-update state with `git stash && bun install --frozen-lockfile` and skip the package.
@@ -93,7 +93,7 @@ Packages classified as Individual (both originally Individual and those promoted
   - Code improvements that leverage new or improved APIs.
   - Replacement of deprecated APIs.
 - PR body: updated package, before/after versions, affected project code or behavior, summary of changes made, and rationale for any items left unaddressed.
-- If tests still fail after 5 fix attempts (one attempt = one cycle of code change → `bun run --bun test && bun run --bun type-check && bun run --bun lint && bun run knip`), create a GitHub Issue and a Draft PR, then stop.
+- If tests still fail after 5 fix attempts (one attempt = one cycle of code change → `bun run --bun test && bun run --bun typecheck && bun run --bun lint && bun run knip`), create a GitHub Issue and a Draft PR, then stop.
   - Title: `[Package Name] from vA to vB`
   - Body: error details, the upstream change causing the impact, affected project code or behavior, and approaches attempted.
   - After creating the Issue, create a Draft PR and include a link to the Issue in its description.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           bun-version: "1.3.11"
       - run: bun install --frozen-lockfile
-      - run: bun run --bun type-check
+      - run: bun run --bun typecheck
       - run: bun run --bun test
       - run: bun run --bun lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ See root `package.json` scripts. Run from repo root via `bun run --bun <script>`
 
 ## Development Workflow
 After implementing, the task is not done until all of the following pass:
-1. `bun run --bun test` · 2. `bun run --bun type-check` · 3. `bun run --bun format` · 4. `bun run --bun lint` · 5. `bun run knip`
+1. `bun run --bun test` · 2. `bun run --bun typecheck` · 3. `bun run --bun format` · 4. `bun run --bun lint` · 5. `bun run knip`
 
 ## Knowledge Management
 - **Update CLAUDE.md** when project structure, dev conventions, or the tech stack changes materially.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ bun run --bun dev
 ```bash
 bun run --bun lint        # リンティング
 bun run --bun format      # フォーマット
-bun run --bun type-check  # 型チェック
+bun run --bun typecheck   # 型チェック
 bun run --bun test        # テスト
 bun run --bun build       # ビルド
 bun run --bun deploy      # Cloudflare Workersにデプロイ

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "test": "bun test",
     "lint": "oxlint && oxfmt --check ./src",
     "format": "oxlint --fix && oxfmt --write ./src",
-    "type-check": "oxlint --type-aware --type-check",
+    "typecheck": "oxlint --type-aware --type-check",
     "dev": "bun --hot --port 8787 ./src/index.ts",
     "preview": "wrangler dev --port 8787",
     "deploy": "wrangler deploy"

--- a/docs/dev/testing-strategy.md
+++ b/docs/dev/testing-strategy.md
@@ -217,7 +217,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3  # v2.1.2
       - run: bun install --frozen-lockfile
-      - run: bun run --bun type-check
+      - run: bun run --bun typecheck
       - run: bun run --bun test
       - run: bun run --bun lint
 ```
@@ -233,7 +233,7 @@ Place tests in same directory as target with `.test.ts` suffix (follows existing
 
 At each Phase completion, execute:
 1. `bun run --bun test` — All tests pass
-2. `bun run --bun type-check` — No type errors
+2. `bun run --bun typecheck` — No type errors
 3. `bun run --bun format` — Format
 4. `bun run --bun lint` — No lint errors
 5. Confirm threshold achievement in coverage report

--- a/docs/dev/testing-strategy.md
+++ b/docs/dev/testing-strategy.md
@@ -97,7 +97,7 @@ Test multiple patterns of same logic efficiently. Use for `resolveDynamicValue` 
 3. [Green]    Write minimal implementation code
 4. [Run]      Confirm test passes
 5. [Refactor] Refactoring
-6. [Verify]   test → type-check → format → lint all pass
+6. [Verify]   test → typecheck → format → lint all pass
 ```
 
 ### AI Development Notes
@@ -164,7 +164,7 @@ Test multiple patterns of same logic efficiently. Use for `resolveDynamicValue` 
 | Zod schema boundaries | `frontend/src/db/schemas.test.ts` (new) | ~10 |
 
 **CI Pipeline:**
-- `.github/workflows/ci.yml` (new) — test → type-check → lint
+- `.github/workflows/ci.yml` (new) — test → typecheck → lint
 
 ### Projections
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "oxlint && oxfmt --check ./src ./test",
     "format": "oxlint --fix && oxfmt --write ./src ./test",
-    "type-check": "oxlint --type-aware --type-check",
+    "typecheck": "oxlint --type-aware --type-check",
     "dev": "vite --port 3000",
     "build": "vite build && tsc",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "bun --filter '*' lint",
     "format": "bun --filter '*' format",
-    "type-check": "bun --filter '*' type-check",
+    "typecheck": "bun --filter '*' typecheck",
     "dev": "bun --filter '*' dev",
     "build": "bun --filter '*' build",
     "deploy": "bun --filter '*' deploy",


### PR DESCRIPTION
## Summary

- `type-check` → `typecheck` across all workspaces (root, frontend, backend)
- Updated all references in CLAUDE.md, README.md, docs, and skills
- Fixed PostToolUse hook: replaced bash-specific `[[`/`=~` with POSIX `case` statement (was failing under `/bin/sh`)

## Test plan

- [ ] `bun run --bun typecheck` runs successfully in each workspace
- [ ] No remaining references to `type-check` script name

🤖 Generated with [Claude Code](https://claude.com/claude-code)