### PR TITLE
feat(frontend): add Google Analytics GA4 tracking

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" href="/favicon.ico" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://gm-assistant-bot-api.bidri.dev; img-src 'self' data: https://cdn.discordapp.com; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:"
+      content="default-src 'self'; script-src 'self' https://static.cloudflareinsights.com https://www.googletagmanager.com 'sha256-AEp7fPy6lEZUibfBm5EpRgaohKT5eg4TQXX2teIY7nY='; connect-src 'self' https://gm-assistant-bot-api.bidri.dev https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com; img-src 'self' data: https://cdn.discordapp.com; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:"
     />
     <meta name="theme-color" content="#000000" />
     <meta
@@ -16,6 +16,14 @@
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
     <title>GM Assistant Bot</title>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-05FZ21G8P1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-05FZ21G8P1', { send_page_view: false });
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -1,2 +1,2 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://gm-assistant-bot-api.bidri.dev; img-src 'self' data: https://cdn.discordapp.com; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com https://www.googletagmanager.com 'sha256-AEp7fPy6lEZUibfBm5EpRgaohKT5eg4TQXX2teIY7nY='; connect-src 'self' https://gm-assistant-bot-api.bidri.dev https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com; img-src 'self' data: https://cdn.discordapp.com; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -1,8 +1,8 @@
 import { TanStackDevtools } from "@tanstack/react-devtools";
 import { Outlet, createRootRoute, useRouteContext, useRouter } from "@tanstack/react-router";
 import { Link } from "@tanstack/react-router";
-import { useEffect } from "react";
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
+import { useEffect } from "react";
 import { FaDiscord } from "react-icons/fa";
 import { LuLayoutTemplate, LuPanelLeftOpen } from "react-icons/lu";
 import { SiSessionize } from "react-icons/si";

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import { TanStackDevtools } from "@tanstack/react-devtools";
-import { Outlet, createRootRoute, useRouteContext } from "@tanstack/react-router";
+import { Outlet, createRootRoute, useRouteContext, useRouter } from "@tanstack/react-router";
 import { Link } from "@tanstack/react-router";
+import { useEffect } from "react";
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 import { FaDiscord } from "react-icons/fa";
 import { LuLayoutTemplate, LuPanelLeftOpen } from "react-icons/lu";
@@ -10,6 +11,10 @@ import { ThemeIcon } from "@/theme/ThemeIcon";
 import { ThemeProvider } from "@/theme/ThemeProvider";
 import { ThemeSwichMenu } from "@/theme/ThemeSwichMenu";
 import { ToastProvider } from "@/toast/ToastProvider";
+
+declare global {
+  function gtag(...args: unknown[]): void;
+}
 
 interface RootContext {
   layoutMode: "padded" | "full-height";
@@ -22,6 +27,14 @@ export const Route = createRootRoute({
 function RootComponent() {
   const context = useRouteContext({ from: "__root__" }) as RootContext | undefined;
   const layoutMode = context?.layoutMode ?? "padded";
+  const router = useRouter();
+
+  useEffect(() => {
+    gtag("event", "page_view", { page_path: window.location.pathname + window.location.search });
+    return router.subscribe("onResolved", () => {
+      gtag("event", "page_view", { page_path: window.location.pathname + window.location.search });
+    });
+  }, [router]);
 
   return (
     <ThemeProvider>


### PR DESCRIPTION
## Summary

- GA4 タグ `G-05FZ21G8P1` を追加（gtag.js スニペットを `index.html` に挿入）
- TanStack Router の `onResolved` イベントで SPA ナビゲーション時の `page_view` を追跡
- CSP を更新 — インラインスクリプトを SHA-256 ハッシュで許可、GA4 収集エンドポイント（ワイルドカード含む）を追加

## 技術的な判断

- `send_page_view: false` で gtag 自動送信を無効化し、`useEffect` で初回 + `onResolved` で以降のページビューを明示的に送信
- `@types/gtag.js` はメンテされていないため不使用、最小限の `declare global` で型宣言
- CSP のインラインスクリプト許可は `'unsafe-inline'` を使わず SHA-256 ハッシュで対応

## Test plan

- [ ] ブラウザの DevTools Console で CSP エラーなし確認
- [ ] Network タブで `https://www.google-analytics.com/g/collect` がページ遷移ごとに発火確認
- [ ] GA4 リアルタイムレポートでページビューが来ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)