### PR TITLE
docs: rewrite testing-strategy and node-system-architecture for clarity

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+worktrees/

--- a/docs/dev/node-system-architecture.md
+++ b/docs/dev/node-system-architecture.md
@@ -1,206 +1,99 @@
-# ノードベースワークフローシステム アーキテクチャ
+# Node-Based Workflow System Architecture
 
-> このドキュメントは、新しいノードタイプを実装する際の参照用です。
+> Read this before implementing a new node type. For step-by-step implementation procedures, see `.claude/skills/node-creator/SKILL.md`.
 
-## 概要
+## Overview
 
-このプロジェクトは、TRPG/マーダーミステリーセッション管理のためのノードベースワークフローシステムを実装しています。React Flow (@xyflow/react) を使用し、ノードの編集（テンプレート作成）と実行（セッション管理）の2つのモードをサポートします。
+A node-based workflow system for managing TRPG / murder-mystery sessions. Built on React Flow (`@xyflow/react`). Nodes operate in two modes:
 
----
+- **Edit mode** — Template authoring. Data is editable. No execute button. No execution context.
+- **Execute mode** — Session runtime. Data is read-only. Execute button is shown. Execution context is provided.
 
-## 既存ノードタイプ一覧
-
-| ノードタイプ | 役割 | 幅 |
-|-------------|------|-----|
-| CreateCategory | Discord カテゴリを作成 | md (256px) |
-| CreateRole | Discord ロールを複数作成 | md |
-| CreateChannel | テキスト/ボイスチャンネル作成＆権限設定 | lg (480px) |
-| DeleteCategory | カテゴリの削除 | md |
-| DeleteRole | ロール削除（全体または指定） | md |
-| DeleteChannel | チャンネル削除（指定名） | md |
-| ChangeChannelPermission | チャンネル権限を更新 | md |
-| AddRoleToRoleMembers | ロールメンバーに別のロール付与 | md |
-| SendMessage | チャンネルへメッセージ送信＆ファイル添付 | lg |
-| Blueprint | マーダーミステリー基本セット（展開ノード） | lg |
-| SetGameFlag | セッションのゲームフラグ設定 | md |
-| RecordCombination | 組み合わせペアを記録 | lg |
-| Kanban | カンバンボード | xl (640px) |
-| LabeledGroup | ノードをグループ化するコンテナ | xl |
-| Comment | ワークフロー内のコメント | md |
+The full list of node types lives in `frontend/src/components/Node/nodes/`. It changes frequently and is intentionally not enumerated here.
 
 ---
 
-## ノードの基本構造
+## Node basics
 
-### ベーススキーマ
+### Base schema
 
-すべてのノードは `BaseNodeDataSchema` を拡張します。
+Every node extends `BaseNodeDataSchema`:
 
-```typescript
+```ts
 // frontend/src/components/Node/base/base-schema.ts
 export const BaseNodeDataSchema = z.object({
-  executedAt: z.coerce.date().optional(),  // 実行完了時刻
+  executedAt: z.coerce.date().optional(), // set when execution completes
 });
 ```
 
-### ノード幅の定義
+By convention each node also defines a `title: z.string().default(...)` field for the inline-editable header.
 
-```typescript
-export const NODE_WIDTHS = {
-  sm: 192,  // 12 × 16px
-  md: 256,  // 16 × 16px（標準）
-  lg: 480,  // 30 × 16px（複雑なノード用）
-  xl: 640,  // 40 × 16px（グループノード用）
-} as const;
+### Width and content height
+
+```ts
+// frontend/src/components/Node/base/base-schema.ts
+const NODE_WIDTHS = {
+  sm: 192, // 12 × 16
+  md: 256, // 16 × 16 (default)
+  lg: 480, // 30 × 16 (complex nodes)
+  xl: 640, // 40 × 16 (group nodes)
+};
 
 export const NODE_TYPE_WIDTHS: Record<string, NodeWidth> = {
-  CreateRole: NODE_WIDTHS.md,
-  CreateChannel: NODE_WIDTHS.lg,
-  // ... 新しいノードもここに追加
+  /* one entry per node type */
+};
+
+export const NODE_CONTENT_HEIGHTS = {
+  sm: 200,
+  md: 300,
+  lg: 400,
 };
 ```
 
-### コンテンツ高さの定義
-
-```typescript
-export const NODE_CONTENT_HEIGHTS = {
-  sm: 200,  // 小さいノード
-  md: 300,  // 標準ノード
-  lg: 400,  // 大きい/複雑なノード
-} as const;
-```
+Add an entry to `NODE_TYPE_WIDTHS` when introducing a new node type.
 
 ---
 
-## ノードコンポーネントの実装パターン
+## Node component pattern
 
-### 基本構造
+Skeleton only. The full template lives in `.claude/skills/node-creator/SKILL.md`.
 
-```typescript
-// frontend/src/components/Node/nodes/ExampleNode.tsx
+```tsx
 import { Position, type Node, type NodeProps } from "@xyflow/react";
-import { useState } from "react";
 import z from "zod";
 
-import { useTemplateEditorStore } from "@/stores/templateEditorStore";
-import { useToast } from "@/toast/ToastProvider";
-
 import {
-  BaseHandle,
-  BaseNode,
-  BaseNodeContent,
-  BaseNodeFooter,
-  BaseNodeHeader,
-  BaseNodeHeaderTitle,
-  EditableTitle,
-  cn,
-  BaseNodeDataSchema,
-  NODE_CONTENT_HEIGHTS,
-  NODE_TYPE_WIDTHS,
+  BaseHandle, BaseNode, BaseNodeContent, BaseNodeFooter,
+  BaseNodeHeader, BaseNodeHeaderTitle, EditableTitle,
+  BaseNodeDataSchema, NODE_CONTENT_HEIGHTS, NODE_TYPE_WIDTHS,
 } from "../base";
 import { useNodeExecutionOptional } from "../contexts";
 
-// 1. スキーマ定義
 export const DataSchema = BaseNodeDataSchema.extend({
-  title: z.string().default("ノードのデフォルトタイトル"),  // 編集可能タイトル
-  // ノード固有のデータフィールド
-  myField: z.string(),
+  title: z.string().default("Default title"),
+  // node-specific fields
 });
 
 type ExampleNodeData = Node<z.infer<typeof DataSchema>, "Example">;
 
-// 2. コンポーネント定義
 export const ExampleNode = ({
-  id,
-  data,
-  mode = "edit",
+  id, data, mode = "edit",
 }: NodeProps<ExampleNodeData> & { mode?: "edit" | "execute" }) => {
-  const updateNodeData = useTemplateEditorStore((state) => state.updateNodeData);
-  const executionContext = useNodeExecutionOptional();
-  const { addToast } = useToast();
-
-  const [isLoading, setIsLoading] = useState(false);
-
-  // 3. データ更新ハンドラ
-  const handleTitleChange = (newTitle: string) => {
-    updateNodeData(id, { title: newTitle });
-  };
-
-  const handleFieldChange = (newValue: string) => {
-    updateNodeData(id, { myField: newValue });
-  };
-
-  // 4. 実行ハンドラ（execute mode用）
-  const handleExecute = async () => {
-    if (!executionContext) {
-      addToast({ message: "実行コンテキストがありません", status: "error" });
-      return;
-    }
-
-    setIsLoading(true);
-    try {
-      // Discord API呼び出しなど
-      // await client.doSomething();
-
-      // 成功時
-      updateNodeData(id, { executedAt: new Date() });
-      addToast({ message: "実行完了", status: "success" });
-    } catch (error) {
-      addToast({ message: "実行失敗", status: "error" });
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   const isExecuteMode = mode === "execute";
   const isExecuted = !!data.executedAt;
+  // In execute mode, fetch context with useNodeExecutionOptional()
 
-  // 5. レンダリング
   return (
-    <BaseNode
-      width={NODE_TYPE_WIDTHS.Example}
-      className={cn("bg-base-300", data.executedAt && "border-success bg-success/10")}
-    >
+    <BaseNode width={NODE_TYPE_WIDTHS.Example}>
       <BaseNodeHeader>
-        {isExecuteMode ? (
-          <BaseNodeHeaderTitle>{data.title || "ノードのデフォルトタイトル"}</BaseNodeHeaderTitle>
-        ) : (
-          <EditableTitle
-            title={data.title}
-            defaultTitle="ノードのデフォルトタイトル"
-            onTitleChange={handleTitleChange}
-          />
-        )}
+        {isExecuteMode
+          ? <BaseNodeHeaderTitle>{data.title}</BaseNodeHeaderTitle>
+          : <EditableTitle title={data.title} defaultTitle="Default title" onTitleChange={/* ... */} />}
       </BaseNodeHeader>
-
       <BaseNodeContent maxHeight={NODE_CONTENT_HEIGHTS.md}>
-        {/* Edit mode: 編集可能なフォーム */}
-        {/* Execute mode: 読み取り専用の表示 */}
-        <input
-          type="text"
-          className="nodrag input input-bordered w-full"
-          value={data.myField}
-          onChange={(e) => handleFieldChange(e.target.value)}
-          disabled={isExecuteMode || isLoading || isExecuted}
-        />
+        {/* edit / display UI */}
       </BaseNodeContent>
-
-      {/* Execute mode時のみフッター表示 */}
-      {isExecuteMode && (
-        <BaseNodeFooter>
-          <button
-            type="button"
-            className="nodrag btn btn-primary"
-            onClick={handleExecute}
-            disabled={isLoading || isExecuted}
-          >
-            {isLoading && <span className="loading loading-spinner loading-sm" />}
-            実行
-          </button>
-        </BaseNodeFooter>
-      )}
-
-      {/* 接続ハンドル */}
+      {isExecuteMode && <BaseNodeFooter>{/* execute button */}</BaseNodeFooter>}
       <BaseHandle id="target-1" type="target" position={Position.Left} />
       <BaseHandle id="source-1" type="source" position={Position.Right} />
     </BaseNode>
@@ -208,44 +101,41 @@ export const ExampleNode = ({
 };
 ```
 
----
+### Base components
 
-## UIコンポーネント
+Re-exported from `frontend/src/components/Node/base/`:
 
-### BaseNode コンポーネント群
+| Name | Purpose |
+|------|---------|
+| `BaseNode` | Top-level node container |
+| `BaseNodeHeader` / `BaseNodeHeaderTitle` | Header |
+| `BaseNodeContent` | Scrollable body (controlled by `maxHeight`) |
+| `BaseNodeFooter` | Footer (execute button etc.) |
+| `BaseHandle` / `LabeledHandle` | Connection handles |
+| `EditableTitle` | Inline-editable title for edit mode |
+| `cn` | Class-name join utility |
 
-```typescript
-// frontend/src/components/Node/base/base-node.tsx
-export function BaseNode({ className, width, style, ...props })
-export function BaseNodeHeader({ className, ...props })
-export function BaseNodeHeaderTitle({ className, ...props })
-export function BaseNodeContent({ className, maxHeight, ...props })
-export function BaseNodeFooter({ className, ...props })
-export function BaseHandle({ className, ...props })
-export function LabeledHandle({ title, position, ...props })
-```
+### Important CSS classes
 
-### 重要なクラス
-
-- `nodrag`: React Flow のドラッグを無効化（input要素などに必須）
-- `bg-base-300`: 標準の背景色
-- `border-success bg-success/10`: 実行完了時のスタイル
+- `nodrag` — Disables React Flow drag. **Required** on `input`, `textarea`, `button`, and other interactive elements.
+- `bg-base-300` — Default background.
+- `border-success bg-success/10` — Conventional style applied when `data.executedAt` is set.
 
 ---
 
-## Edit Mode vs Execute Mode
+## Edit mode vs execute mode
 
-| 観点 | Edit Mode | Execute Mode |
-|------|-----------|--------------|
-| 用途 | テンプレート設計時 | セッション実行時 |
-| データ編集 | 可能 | 不可（表示のみ） |
-| 実行ボタン | 非表示 | 表示 |
-| 削除ボタン | 表示 | 非表示 |
-| 実行コンテキスト | なし | あり（guildId, sessionId, bot等） |
+| Aspect | Edit mode | Execute mode |
+|--------|-----------|--------------|
+| Purpose | Template authoring | Session runtime |
+| Data editing | Allowed | Read-only |
+| Execute button | Hidden | Shown |
+| Delete button | Shown | Hidden |
+| Execution context | None | Provided |
 
-### 実行コンテキスト
+### Execution context
 
-```typescript
+```ts
 // frontend/src/components/Node/contexts/NodeExecutionContext.tsx
 interface NodeExecutionContextValue {
   guildId: string;
@@ -255,258 +145,136 @@ interface NodeExecutionContextValue {
 }
 ```
 
----
-
-## ストア統合
-
-### templateEditorStore.ts への追加手順
-
-1. **型のインポート**
-```typescript
-import type { ExampleDataSchema } from "@/components/Node";
-```
-
-2. **型定義の追加**
-```typescript
-export type ExampleNodeData = z.infer<typeof ExampleDataSchema>;
-```
-
-3. **FlowNode union型への追加**
-```typescript
-export type FlowNode =
-  | Node<ExampleNodeData, "Example">
-  | // ... 既存の型
-```
-
-4. **addNode関数への追加**
-```typescript
-} else if (type === "Example") {
-  newNode = {
-    id,
-    type,
-    position,
-    data: {
-      title: "ノードのデフォルトタイトル",
-      myField: "",
-    },
-  };
-}
-```
-
-5. **updateNodeData の型にも追加**
-```typescript
-updateNodeData: (
-  nodeId: string,
-  data: Partial<
-    | ExampleNodeData
-    | // ... 既存の型
-  >,
-) => void;
-```
-
-6. **addNode の type 引数にも追加**
-```typescript
-addNode: (
-  type:
-    | "Example"
-    | // ... 既存の型
-  position: { x: number; y: number },
-) => void;
-```
+Nodes call `useNodeExecutionOptional()` to obtain it. The return value can be `null`, so guard before use.
 
 ---
 
-## node-wrapper.tsx への登録
+## DynamicValue system
 
-```typescript
-// frontend/src/components/Node/base/node-wrapper.tsx
-import { ExampleNode } from "../nodes/ExampleNode";
+Resolves node parameters dynamically — literals, session names, role/channel references, and game flags — through a single discriminated union.
 
-export function createNodeTypes(mode: "edit" | "execute" = "edit"): NodeTypes {
-  const ExampleWithMode: ComponentType<NodeProps<any>> = (props) => (
-    <ExampleNode {...props} mode={mode} />
-  );
-
-  return {
-    Example: ExampleWithMode,
-    // ... 既存のノード
-  };
-}
-```
-
----
-
-## TemplateEditor.tsx への追加
-
-```typescript
-// frontend/src/components/TemplateEditor.tsx
-const NODE_CATEGORIES = [
-  {
-    category: "カテゴリ名",
-    nodes: [
-      { type: "Example", label: "サンプルノード" },
-      // ...
-    ],
-  },
-  // ...
-] as const;
-```
-
----
-
-## 新しいノード実装のチェックリスト
-
-1. [ ] `frontend/src/components/Node/nodes/NewNode.tsx` を作成
-   - DataSchema を定義
-   - コンポーネントを実装
-2. [ ] `frontend/src/components/Node/base/base-schema.ts` に幅を追加
-   - `NODE_TYPE_WIDTHS` に追加
-3. [ ] `frontend/src/components/Node/base/node-wrapper.tsx` に登録
-   - インポート追加
-   - `createNodeTypes` 関数内で mode を注入
-4. [ ] `frontend/src/components/Node/nodes/index.ts` にエクスポート追加
-   - ノードコンポーネントと DataSchema をエクスポート
-5. [ ] `frontend/src/stores/templateEditorStore.ts` を更新
-   - 型インポート
-   - 型定義追加
-   - FlowNode union型に追加
-   - addNode 関数に初期データ追加
-   - updateNodeData の型に追加
-6. [ ] `frontend/src/components/TemplateEditor.tsx` に追加
-   - `NODE_CATEGORIES` に追加
-
----
-
-## DynamicValue システム
-
-ノードのパラメータを動的に解決するシステム。
-
-```typescript
+```ts
 // frontend/src/components/Node/utils/DynamicValue.ts
 export const DynamicValueSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("literal"), value: z.string() }),
   z.object({ type: z.literal("session.name") }),
+  z.object({ type: z.literal("roleRef"), roleName: z.string() }),
+  z.object({ type: z.literal("channelRef"), channelName: z.string() }),
+  z.object({ type: z.literal("gameFlag"), flagKey: z.string() }),
 ]);
 
-export function resolveDynamicValue(
-  value: DynamicValue,
-  context: { sessionName?: string },
-): string {
-  switch (value.type) {
-    case "literal":
-      return value.value;
-    case "session.name":
-      return context.sessionName ?? "";
-  }
+export interface DynamicValueContext {
+  sessionName?: string;
+  roles?: Map<string, string>;       // roleName -> roleId
+  channels?: Map<string, string>;    // channelName -> channelId
+  gameFlags?: Record<string, string>;
 }
+
+export function resolveDynamicValue(value: DynamicValue, context: DynamicValueContext): string;
 ```
 
-**使用例（CreateCategoryNode）:**
-```typescript
-export const DataSchema = BaseNodeDataSchema.extend({
-  categoryName: DynamicValueSchema,
-});
-```
+Use `DynamicValueSchema` directly as a node field, then call `resolveDynamicValue` at execute time. Adding a new variant requires updating three places: the schema, `DynamicValueContext`, and `resolveDynamicValue`.
 
 ---
 
-## データ永続化
+## Persistence
 
-### ReactFlowData
+Nodes are persisted to IndexedDB via Dexie.js using the React Flow data shape:
 
-```typescript
+```ts
 export const ReactFlowDataSchema = z.object({
   nodes: z.array(z.any()),
   edges: z.array(z.any()),
-  viewport: z.object({
-    x: z.number(),
-    y: z.number(),
-    zoom: z.number(),
-  }),
+  viewport: z.object({ x: z.number(), y: z.number(), zoom: z.number() }),
 });
 ```
 
-- ノードデータは `GameSession.reactFlowData` に JSON 文字列として保存
-- Dexie.js (IndexedDB) を使用
+- Stored on both `Template.reactFlowData` and `GameSession.reactFlowData`.
+- `nodes` is typed as `z.any()`, so each node's `DataSchema` is responsible for validating its own payload at read time.
 
 ---
 
-## 実行フロー
+## Execution flow
 
-1. **検証**: 入力データチェック
-2. **解決**: ロール名→ID変換など参照データ取得
-3. **API呼び出し**: Discord API を通じて実行
-4. **DB保存**: 作成したリソース情報を DB に記録
-5. **ステート更新**: `executedAt` タイムスタンプを設定
-6. **トースト通知**: 実行結果をユーザーに通知
+1. **Validate** — Check inputs.
+2. **Resolve** — Use `resolveDynamicValue` to translate role/channel names to IDs, etc.
+3. **Call** — Hit Discord API.
+4. **Persist** — Record the created resource in the DB.
+5. **Update state** — `updateNodeData(id, { executedAt: new Date() })`.
+6. **Toast** — Notify the user of the result.
 
-### プログレス表示パターン
+### Progress reporting pattern
 
-```typescript
+For nodes that loop (e.g. creating multiple roles), keep a progress counter in state and render a `<progress>` element:
+
+```tsx
 const [progress, setProgress] = useState({ current: 0, total: 0 });
 
-// ループ処理中
 for (let i = 0; i < items.length; i++) {
   setProgress({ current: i + 1, total: items.length });
-  // 処理
+  // work
 }
 
-// UI
 {isLoading && (
-  <progress
-    className="progress progress-primary w-full"
-    value={progress.current}
-    max={progress.total}
-  />
+  <progress className="progress progress-primary w-full"
+    value={progress.current} max={progress.total} />
 )}
 ```
 
 ---
 
-## DataSchema 変更とマイグレーション
+## DataSchema changes and migrations
 
-ノードの `DataSchema` を変更した場合、既存の IndexedDB データとの互換性を保つために Dexie マイグレーションが必要になる。
+### Policy
 
-### 設計方針
+Schema changes are handled via **Dexie DB versioning** (`this.version(N).upgrade()`), not at app startup. This guarantees a one-time, deterministic transformation of stored records.
 
-DataSchema の変更は **DB レベルのマイグレーション** で対応する（アプリ起動時の変換ロジックではなく）。Dexie のバージョニング機構を使うことで、一度だけ確実にデータを変換できる。
+### Key files
 
-### マイグレーション履歴
+| File | Role |
+|------|------|
+| `frontend/src/db/database.ts` | Dexie migration definitions |
+| `frontend/src/db/schemas.ts` | DB table type definitions |
+| `frontend/src/components/Node/nodes/{NodeName}Node.tsx` | The `DataSchema` being changed |
 
-| DB version | 変更内容 |
-|-----------|---------|
-| v1 → v2 | `SendMessageNode.channelName` (string) → `channelNames` (string[]) / `CreateCategoryNode.categoryName` → DynamicValue 型へ |
-| v2 → v3 | `SendMessageNode.channelNames` (string[]) → `channelTargets` (ChannelTarget[]) |
+### Things to watch
 
-### 仕組み（4ステップ）
+- Both `Template` and `GameSession` carry `reactFlowData`. Migrate **both** tables with `modify()`.
+- Define the old shape as a separate `z.object({ ... })` and use `safeParse` to detect legacy records — skip records that already match the new shape.
+- After conversion, `delete node.data.oldField` to remove obsolete keys.
 
-1. **旧スキーマ定義**: `z.object({ ... })` で移行前のデータ形を定義する
-2. **safeParse で条件分岐**: 旧スキーマにマッチするレコードのみ変換する（新スキーマのデータはスキップ）
-3. **両テーブルを移行**: `Template` と `GameSession` の両方に `reactFlowData` が含まれるため、両方を `modify()` する
-4. **旧フィールドを delete**: 変換後は `delete node.data.oldField` で不要フィールドを削除する
+### Procedure
 
-### キーファイル
-
-| ファイル | 役割 |
-|---------|------|
-| `frontend/src/db/database.ts` | Dexie マイグレーション定義（`this.version(N).upgrade()`） |
-| `frontend/src/db/schemas.ts` | DB テーブルの型定義 |
-| `frontend/src/components/Node/nodes/{NodeName}Node.tsx` | ノードの `DataSchema`（変更対象） |
-
-> スキーマ変更の実装手順は [`.claude/skills/schema-migration/SKILL.md`](../../.claude/skills/schema-migration/SKILL.md) を参照。
+See `.claude/skills/schema-migration/SKILL.md` for full templates and worked examples (rename, string → discriminated union, array element type change).
 
 ---
 
-## 関連ファイル
+## Adding a new node type
 
-| ファイル | 説明 |
-|---------|------|
-| `frontend/src/components/Node/base/base-node.tsx` | UIプリミティブ |
-| `frontend/src/components/Node/base/base-schema.ts` | 共通スキーマ・定数 |
-| `frontend/src/components/Node/base/editable-title.tsx` | インライン編集タイトルコンポーネント |
-| `frontend/src/components/Node/base/node-wrapper.tsx` | ノードタイプ登録 |
-| `frontend/src/components/Node/contexts/NodeExecutionContext.tsx` | 実行コンテキスト |
-| `frontend/src/components/Node/utils/DynamicValue.ts` | 動的値システム |
-| `frontend/src/components/Node/nodes/` | 全ノード実装（20種類） |
-| `frontend/src/stores/templateEditorStore.ts` | Zustandストア |
-| `frontend/src/components/TemplateEditor.tsx` | エディタ本体 |
+These files must be edited. None of this is automated by type inference — every list is enumerated by hand.
+
+- `frontend/src/components/Node/nodes/{NodeName}Node.tsx` — create
+- `frontend/src/components/Node/nodes/index.ts` — re-export
+- `frontend/src/components/Node/base/base-schema.ts` — add to `NODE_TYPE_WIDTHS`
+- `frontend/src/components/Node/base/node-wrapper.tsx` — register in `createNodeTypes` (injects `mode`)
+- `frontend/src/stores/templateEditorStore.ts` — extend the `FlowNode` union, the `addNode` switch, and `updateNodeData`'s parameter type (three separate sites)
+- `frontend/src/components/TemplateEditor.tsx` — add to `NODE_CATEGORIES`
+
+**For the full procedure and code templates, follow `.claude/skills/node-creator/SKILL.md`.**
+
+---
+
+## Reference files
+
+| File | Description |
+|------|-------------|
+| `frontend/src/components/Node/base/base-node.tsx` | UI primitives |
+| `frontend/src/components/Node/base/base-schema.ts` | Shared schema and width/height constants |
+| `frontend/src/components/Node/base/editable-title.tsx` | Inline-editable title |
+| `frontend/src/components/Node/base/node-wrapper.tsx` | Node-type registration with `mode` injection |
+| `frontend/src/components/Node/contexts/NodeExecutionContext.tsx` | Execution context provider |
+| `frontend/src/components/Node/utils/DynamicValue.ts` | DynamicValue system |
+| `frontend/src/components/Node/nodes/` | All node implementations |
+| `frontend/src/stores/templateEditorStore.ts` | Zustand store |
+| `frontend/src/components/TemplateEditor.tsx` | Editor entry point |
+| `frontend/src/db/database.ts` | Dexie DB and migrations |

--- a/docs/dev/testing-strategy.md
+++ b/docs/dev/testing-strategy.md
@@ -199,7 +199,7 @@ Do not duplicate config **values** in this doc — files are the source of truth
 |------|----------|
 | Unit / Integration | Co-located in `src/`, `*.test.ts(x)` |
 | VRT | `frontend/test/vrt/*.vrt.ts` |
-| Storybook stories | `frontend/test/stories/**/*.stories.@(ts|tsx|mdx)` |
+| Storybook stories | `frontend/test/stories/**/*.stories.@(ts\|tsx\|mdx)` |
 
 ---
 

--- a/docs/dev/testing-strategy.md
+++ b/docs/dev/testing-strategy.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-AI-driven code generation is central to development, requiring maximized test coverage to ensure generated code quality. Currently, frontend has ~5 test files (125 test cases, ~45% coverage). Backend has no tests. No CI test execution.
+AI-driven code generation is central to development; generated code quality must be backed by sustained high test coverage. This document defines the current strategy combining Unit, Integration, and Visual Regression Test (VRT) layers, on top of the Test Pyramid and TDD.
 
-This strategy establishes comprehensive testing based on the Test Pyramid and TDD, targeting 90%+ coverage while maintaining healthy Code to Test Ratio.
+VRT was introduced via Issue [#141](https://github.com/bi9dri/gm-assistant-bot/issues/141) using Playwright + MSW + Storybook. Baselines are unified on Linux Docker; Chromium only.
 
 ---
 
@@ -12,228 +12,208 @@ This strategy establishes comprehensive testing based on the Test Pyramid and TD
 
 ```
     ┌─────────┐
-    │  E2E    │  → Not in current scope (Phase N+1)
+    │   VRT   │  Playwright + MSW; freeze appearance as fixtures
+    │(Visual) │  Routes / React Flow editor / Storybook stories × light/dark
     ├─────────┤
-    │ Integra-│  25% — Hono route handlers, DB migrations,
-    │  tion   │       store+DB integration
+    │ Integra-│  Hono `app.request()`, fake-indexeddb, etc.
+    │  tion   │  store ↔ DB collaboration, route handler + schema
     ├─────────┤
-    │         │  75% — Pure functions, store actions, Zod schemas,
-    │  Unit   │       DB models, API clients, backend utilities
+    │  Unit   │  pure functions / store actions / Zod schema boundaries / DB model logic
     └─────────┘
 ```
 
-### Unit Test Definition
-Tests single function/module/store action without external dependencies. All external dependencies are mocked.
+### Unit Test
+Verifies a single function / module / store action with all external dependencies mocked.
 
-### Integration Test Definition
-Tests collaboration between 2+ modules. Uses fake-indexeddb or Hono's `app.request()`, but mocks Discord API.
+### Integration Test
+Verifies collaboration between two or more modules. Uses `fake-indexeddb` or Hono's `app.request()`, but mocks Discord API and other external I/O.
 
-### E2E (Deferred to Phase N+1)
-- Current Unit + Integration tests provide sufficient coverage
-- Future consideration: Playwright for critical paths (template import/export, session creation→execution flow)
+### VRT (Visual Regression Test)
+**Visual regression detection only.** Detects changes in CSS / Tailwind / DaisyUI / React Flow / layout by diffing against baseline screenshots. Logic, state transitions, and API correctness are the responsibility of Unit / Integration tests — never VRT.
+
+---
+
+## VRT
+
+### Purpose
+- Tailwind + DaisyUI usage makes CSS-driven visual breakage easy to introduce
+- The React Flow-based template editor is highly susceptible to visual regressions in node rendering, connections, and layout
+- Provide a CI safety net that catches visual diffs
+
+### Scope
+Follows the policy table in [#141](https://github.com/bi9dri/gm-assistant-bot/issues/141).
+
+- **All routes** (template / session / bot)
+- **React Flow template editor** (empty state / single representative node / multiple nodes connected by edges)
+- **Individual components via Storybook stories**
+- **light / dark theme matrix**
+
+### Stack
+| Item | Decision |
+|------|----------|
+| Browser | Chromium only |
+| Snapshot strategy | Playwright's standard `toHaveScreenshot` + git commit |
+| OS-difference handling | Update baselines in the same Linux environment as CI (Playwright official Docker recommended) |
+| External dependency mocking | MSW pins Discord OAuth and the entire `/api`. Activated by passing env `VITE_USE_MSW=true` to the dev server |
+| Component isolation | Storybook + `@storybook/addon-themes`'s `data-theme` decorator for light/dark switching |
+
+### Determinism Principles
+Screenshots must be deterministic to be meaningful. The following must always hold project-wide:
+
+- Disable animations (`animations: "disabled"`) and hide caret (`caret: "hide"`)
+- Keep `maxDiffPixelRatio` conservative; do not let small diffs slip through
+- Mask dynamic elements (timestamps, random IDs, counters) or pin them with a fixed seed
+- Wait for `document.fonts.ready` before capturing
+- Pin React Flow viewport by explicitly calling `fitView`
+- Set `prefers-reduced-motion` on the browser context
+
+### Known Workaround
+Starting the VRT dev server with the Bun runtime (`bun --bun`) hits an Internal Server Error caused by the Tailwind + `@tailwindcss/vite` + DaisyUI plugin combination. The `webServer.command` in `frontend/playwright.config.ts` therefore **does not** include `--bun`. The reason and reproduction conditions are documented as a comment in that file — always consult it before modifying the config.
+
+### Snapshot Operations
+- Commit baselines to git
+- Layout: auto-organized next to `frontend/test/vrt/{name}.vrt.ts` as `*.vrt.ts-snapshots/{arg}-{projectName}-{platform}{ext}`
+- Update baselines in the same Linux environment as CI. Updating from local macOS or similar mass-produces false positives from pixel differences
+- CI integration (fail on diff in PRs / upload diff PNGs as artifacts) and the baseline update workflow are owned by **Issue [#144](https://github.com/bi9dri/gm-assistant-bot/issues/144)** and the upcoming `docs/dev/visual-regression-testing.md`
+
+### What VRT Does Not Cover
+- Logic verification after a button click (Unit / Integration responsibility)
+- Correctness of API response parsing (covered by backend Unit tests)
+- Fine-grained assertions (do not use `toHaveText` and similar in VRT — screenshot diffing is sufficient)
 
 ---
 
 ## Coverage Strategy
 
-### Target Metrics
+Coverage is a **guideline**, not a hard requirement. Chasing 100% generates low-value tests (re-export coverage, exhaustive JSX branches, etc.) and degrades the Code-to-Test Ratio. Set realistic thresholds.
 
-| Metric     | Target |
-|------------|--------|
-| Lines      | 90%    |
-| Functions  | 95%    |
-| Statements | 90%    |
+### Direction
 
-Target 90-95% instead of 100% to avoid coverage-first approach that generates low-value tests (re-export coverage, exhaustive JSX branches) and worsens Code to Test Ratio.
+| Metric | Direction |
+|--------|-----------|
+| Lines | Keep high |
+| Statements | Keep high |
+| Functions | Allowed to be lower (UI-side helpers cannot always be excluded cleanly) |
 
-### Coverage Exclusions
-- `routeTree.gen.ts` — Auto-generated
-- `main.tsx` — Entry point (boot only)
-- `**/index.ts` — Re-export only files
-- `routes/__root.tsx` — Root layout
+The actual thresholds live in `frontend/bunfig.toml` / `backend/bunfig.toml` and are the source of truth. Do not duplicate them in this doc (avoids drift).
 
-### 100% Target Code (logic correctness = app reliability)
-- `stores/templateEditorStore.ts`
-- `components/Node/utils/DynamicValue.ts`
-- `db/models/Template.ts`, `db/models/GameSession.ts`
-- `api.ts`, `fileSystem.ts`
-- `backend/src/discord.ts`, `backend/src/index.ts`, `backend/src/schemas.ts`
+### High-Coverage Targets
+Code where logical correctness directly drives application reliability:
 
-### Low Coverage Acceptable
-- `routes/*.tsx` — UI composition only
-- `theme/*.tsx`, `toast/` — Visual display only
-- Entity-only DB models (`DiscordBot.ts`, `Guild.ts`, `Category.ts`, `Channel.ts`, `Role.ts`) — No logic
+- store actions (template editor state transitions)
+- node utility functions (dynamic value resolution, condition evaluation, resource collection, shuffle, etc.)
+- Zod schema boundary values / transformations / errors
+- DB model logic (non-entity-only models)
+- Backend Discord integration / Hono route handlers / schemas
+
+### Low-Coverage Acceptable (or Excluded)
+- Route components (`routes/*.tsx`), theme, toast, and other display-only code → **covered by VRT instead**
+- Logic-free DB entity models
+- `database.ts` Dexie upgrade callback (hard to test due to Dexie internal API dependencies)
+- `api.ts` (covered indirectly by backend tests)
+- `fileSystem.ts` and OPFS-dependent helpers (mostly external API dependent)
+- React contexts / hooks
+
+The actual exclusion patterns live in `frontend/bunfig.toml`'s `coveragePathIgnorePatterns`.
 
 ---
 
-## Code to Test Ratio Guidelines
+## Code-to-Test Ratio
 
-**Target ratio: 1:1.5～1:2.0** (1.5～2 lines of test per line of production code)
+**Target: 1:1.5–1:2.0** (1.5 to 2 lines of test per line of production code)
 
 ### Efficiency Techniques
 
-#### a. Test Data Factories (`frontend/test/factories.ts`)
-Manage test data centrally, write only diffs in each test. Consolidates local helpers from existing `GameSession.test.ts`.
+- **Test data factories**: consolidate fixtures shared across tests in one place
+- **Parameterized tests** (`test.each`): batch the many patterns of a single logic (each dynamic value type, Zod boundary values)
 
-#### b. Parameterized Tests (`test.each`)
-Test multiple patterns of same logic efficiently. Use for `resolveDynamicValue` 5 types and Zod schema boundary values.
+### What Not to Test
 
-#### c. What NOT to Test
 | Target | Reason |
 |--------|--------|
-| Zod schema "happy path only" tests | Repeats schema definition. Test boundaries/transformations/errors only |
-| React Flow internal behavior | Library guarantees |
-| Static text existence checks | Low regression detection power |
-| console.log/error output | Non-essential side effects |
+| Zod schema "happy path only" tests | Mirror of the schema definition. Test boundaries / transformations / errors only |
+| React Flow internals | Library guarantees |
+| Static text existence checks | Low regression-detection power |
+| `console.log` / `console.error` output | Non-essential side effect |
 
 ---
 
-## TDD Workflow (AI Development)
+## TDD Workflow (AI-Development Premise)
 
 ### Basic Flow
 ```
-1. [Red]      Write test first — Define expected behavior
-2. [Run]      bun run --bun test to confirm failure
-3. [Green]    Write minimal implementation code
-4. [Run]      Confirm test passes
-5. [Refactor] Refactoring
-6. [Verify]   test → typecheck → format → lint all pass
+1. [Red]      Write the test first — define expected behavior
+2. [Run]      bun run --bun test, confirm failure
+3. [Green]    Write minimal implementation
+4. [Run]      Confirm pass
+5. [Refactor] Refactor
+6. [Verify]   test → typecheck → format → lint → knip all pass
 ```
 
-### AI Development Notes
-- **Red phase is critical**: Opportunity to verify AI understands "expected behavior"
-- **Green phase**: AI tends to output complete implementation at once → consciously constrain to minimal implementation
-- **Refactor phase**: AI-generated code tends to be verbose → actively slim down
+### Notes for AI Development
+- **Red phase is critical**: this is where you verify the AI correctly understands the expected behavior
+- **Green phase**: AI tends to dump a complete solution at once → consciously constrain it to a minimal implementation
+- **Refactor phase**: AI-generated code tends to be verbose → actively slim it down
 
 ### Application Timing
-- **New feature**: Test → Implementation → Verification
-- **Bug fix**: Add reproduction test → Fix → Confirm no regression
-- **Refactoring**: No test changes → Code changes → Confirm tests pass
+- **New feature**: test → implementation → verification
+- **Bug fix**: add reproduction test → fix → confirm no regression
+- **Refactor**: no test changes → code changes → confirm tests still pass
 
 ---
 
 ## Anti-Patterns
 
-1. **Zod schema "mirror" tests** — Parse valid value to confirm same value returns → Test boundaries/transformation logic/errors only
-2. **Implementation detail tests** — Spy on Zustand's internal `setState` → Test results (state changes)
-3. **Async timing dependencies** — Wait with `setTimeout` → Make deterministic with `Date.now` mock
-4. **Discord API over-mocking** — Test REST client internal structure → Test input/output correspondence
-5. **Component existence tests** — Check static text → Test state changes from user operations
+### Cross-Layer
+1. **Zod schema "mirror" tests** — parsing a valid value just to confirm it round-trips → test boundaries / transformations / errors only
+2. **Implementation-detail tests** — spying on Zustand's internal `setState` → test results (state changes) instead
+3. **Async timing dependencies** — waiting via `setTimeout` → make it deterministic by mocking `Date.now`, etc.
+4. **Discord API over-mocking** — testing the REST client's internal structure → test only input/output correspondence
+5. **Component existence tests** — checking static text → test state transitions driven by user interaction
+
+### VRT-Specific
+6. **Capturing dynamic elements without masking** — timestamps / random values / mid-animation frames cause flakiness
+7. **Capturing React Flow without fixing the viewport** — without `fitView` (or equivalent) zoom/pan drift triggers diffs
+8. **Multiple Storybook screenshots without changing `args`** — the story has no purpose
+9. **Fine-grained assertions in VRT** — keep `toHaveText`-style checks in Unit/Integration. Screenshot diffing is enough for VRT
 
 ---
 
-## Implementation Roadmap
+## Where Infrastructure Settings Live
 
-### Phase 1: Foundation + High-Value Unit Tests ✅
+Do not duplicate config **values** in this doc — files are the source of truth. This keeps the doc from drifting when values change.
 
-**Infrastructure:**
-- `frontend/bunfig.toml` — Add coverage config
-- `backend/bunfig.toml` — Create new (coverage config)
-- `backend/package.json` — Add `"test": "bun test"` script
-- `frontend/test/factories.ts` — Create test data factory
-
-**Tests Added (Frontend):**
-
-| Target | Test File | Est. Cases |
-|--------|-----------|------------|
-| `expandBlueprint()` | `stores/templateEditorStore.test.ts` (append) | ~15 |
-| `resolveDynamicValue()` | `components/Node/utils/DynamicValue.test.ts` (new) | ~10 |
-| RecordCombination pure functions | `components/Node/utils/recordCombination.test.ts` (new) | ~18 |
-| `fisherYatesShuffle()` | `components/Node/utils/shuffle.test.ts` (new) | ~5 |
-
-**Source Code Changes:**
-- Extract `getFilteredTargetOptions`, `validatePair` from `RecordCombinationNode.tsx` to `recordCombination.ts`
-- Extract `fisherYatesShuffle` from `ShuffleAssignNode.tsx` to `shuffle.ts`
-
-### Phase 2: Backend Tests
-
-| Target | Test File | Est. Cases |
-|--------|-----------|------------|
-| Utility functions | `backend/src/discord.test.ts` (new) | ~10 |
-| Zod schema boundaries | `backend/src/schemas.test.ts` (new) | ~15 |
-| Hono route handlers | `backend/src/index.test.ts` (new) | ~20 |
-
-**Source Code Changes:**
-- Export utility functions in `discord.ts`
-
-### Phase 3: Frontend Remaining Coverage + CI
-
-| Target | Test File | Est. Cases |
-|--------|-----------|------------|
-| DB migrations | `frontend/src/db/database.test.ts` (new) | ~6 |
-| Zod schema boundaries | `frontend/src/db/schemas.test.ts` (new) | ~10 |
-
-**CI Pipeline:**
-- `.github/workflows/ci.yml` (new) — test → typecheck → lint
-
-### Projections
-
-| | New Test Files | Est. Test Cases | Coverage |
-|---|---|---|---|
-| Phase 1 | 3 new + 1 append | ~48 | ~80% |
-| Phase 2 | 3 new | ~45 | ~85% |
-| Phase 3 | 2 new + CI | ~16 | 90%+ |
-| **Total** | **8 new** | **~109** | **90%+** |
-
-Combined with existing 125 cases = total ~234 test cases.
-
----
-
-## Infrastructure Settings
-
-### `frontend/bunfig.toml`
-```toml
-[test]
-preload = ["./test/unit.setup.ts"]
-coverage = true
-coverageReporter = ["text", "lcov"]
-coverageDir = "./coverage"
-coverageThreshold = { lines = 0.9, functions = 0.95, statements = 0.9 }
-coverageSkipTestFiles = true
-```
-
-### `backend/bunfig.toml` (New)
-```toml
-[test]
-coverage = true
-coverageReporter = ["text", "lcov"]
-coverageDir = "./coverage"
-coverageThreshold = { lines = 0.9, functions = 0.95, statements = 0.9 }
-coverageSkipTestFiles = true
-```
-
-### `.github/workflows/ci.yml` (New)
-```yaml
-name: CI
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3  # v2.1.2
-      - run: bun install --frozen-lockfile
-      - run: bun run --bun typecheck
-      - run: bun run --bun test
-      - run: bun run --bun lint
-```
-
-> Note: Hash values unified with those currently used in `deploy-frontend.yml`.
+| Config | Location | Role |
+|--------|----------|------|
+| Frontend coverage thresholds / exclusions | `frontend/bunfig.toml` | `coverageThreshold` / `coveragePathIgnorePatterns` |
+| Backend coverage | `backend/bunfig.toml` | Coverage enabled (thresholds to be added later) |
+| Unit test preload | `frontend/test/unit.setup.ts` | Clear Dexie tables / OPFS in-memory mock |
+| VRT config | `frontend/playwright.config.ts` | testDir / Chromium / determinism / `webServer` |
+| VRT MSW | `frontend/test/vrt/msw/{handlers.ts, browser.ts}` | Per-test handler overrides extend `frontend/test/vrt/fixtures.ts` |
+| Storybook | `frontend/.storybook/{main.ts, preview.ts}` | Isolation for VRT. `viteFinal` deliberately does not spread `vite.config.ts` (avoids tanstackRouter / MSW middleware / devtools conflicts) |
+| CI | `.github/workflows/ci.yml` | typecheck → test → lint. VRT job to be added per [#144](https://github.com/bi9dri/gm-assistant-bot/issues/144) |
 
 ### Test File Placement Convention
-Place tests in same directory as target with `.test.ts` suffix (follows existing pattern).
+
+| Kind | Location |
+|------|----------|
+| Unit / Integration | Co-located in `src/`, `*.test.ts(x)` |
+| VRT | `frontend/test/vrt/*.vrt.ts` |
+| Storybook stories | `frontend/test/stories/**/*.stories.@(ts|tsx|mdx)` |
 
 ---
 
 ## Verification Method
 
-At each Phase completion, execute:
-1. `bun run --bun test` — All tests pass
-2. `bun run --bun typecheck` — No type errors
-3. `bun run --bun format` — Format
-4. `bun run --bun lint` — No lint errors
-5. Confirm threshold achievement in coverage report
+Aligned with the Development Workflow in CLAUDE.md. After implementation, the task is not done until **all** of the following pass:
+
+1. `bun run --bun test` — all tests pass
+2. `bun run --bun typecheck` — no type errors
+3. `bun run --bun format` — formatted
+4. `bun run --bun lint` — no lint errors
+5. `bun run knip` — no unused code detected
+
+VRT-only verification (optional):
+
+- `bun run --bun --filter gm-assistant-bot-frontend test:vrt`
+- The canonical baseline-update command and Linux Docker procedure are defined in [#144](https://github.com/bi9dri/gm-assistant-bot/issues/144) and the upcoming `docs/dev/visual-regression-testing.md`


### PR DESCRIPTION
## Summary

LLM 向けドキュメントとして 2 本の dev docs を全面書き直し、volatile な情報を排除。

### `docs/dev/testing-strategy.md`
- VRT 導入 (#141) で陳腐化していたため、現状 (Unit / Integration / VRT) を反映
- 英語化
- すぐ変動する値 (テストファイル数 / 達成カバレッジ% / 個別ファイルリスト / バージョン pin / Phase ロードマップ) を排除し、設定値は `bunfig.toml` / `playwright.config.ts` を真とする方針へ
- カバレッジは目安 (guideline) 表記に変更
- VRT セクションを新設 (Stack / Determinism / Snapshot 運用 / `--bun` 不使用の workaround / VRT で書かないこと)

### `docs/dev/node-system-architecture.md`
- 英語化
- DynamicValue variants を最新化 (`literal`, `session.name`, `roleRef`, `channelRef`, `gameFlag` を網羅)
- ノードタイプ一覧テーブル / DB マイグレーション履歴テーブル / ノード実装数など volatile な情報を削除
- 実装手順 (`templateEditorStore` / `node-wrapper` / `TemplateEditor` の追加) は `.claude/skills/node-creator/SKILL.md` および `.claude/skills/schema-migration/SKILL.md` 参照に集約
- コードサンプルを骨格のみに簡略化 (~120 行 → ~50 行)

## Test plan
- [ ] GitHub 上で Markdown プレビュー崩れ無し
- [ ] CLAUDE.md の Development Workflow `test · typecheck · format · lint · knip` と Verification Method が一致していること
- [ ] Issue #141 / #144 へのリンクが有効
- [ ] `.claude/skills/node-creator/SKILL.md` および `.claude/skills/schema-migration/SKILL.md` が実在し、参照リンクが有効であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)