### PR TITLE
fix(ccweb): SessionStart で devbox shellenv を直接書き出し PATH を通す

### DIFF
--- a/.claude/scripts/setup-ccweb.sh
+++ b/.claude/scripts/setup-ccweb.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
+: "${CLAUDE_ENV_FILE:?CLAUDE_ENV_FILE must be set}"
+: "${CLAUDE_PROJECT_DIR:?CLAUDE_PROJECT_DIR must be set}"
 
 source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 export PATH="/nix/var/nix/profiles/default/bin:$PATH"
-devbox global add direnv
-eval "$(devbox global shellenv)"
-direnv export bash > "$CLAUDE_ENV_FILE"
+( cd "$CLAUDE_PROJECT_DIR" && devbox shellenv --init-hook=false ) > "$CLAUDE_ENV_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "direnv export bash > \"$CLAUDE_ENV_FILE\""
+            "command": "if [ \"$CLAUDE_CODE_REMOTE\" = \"true\" ]; then ( cd \"$CLAUDE_PROJECT_DIR\" && devbox shellenv --init-hook=false ) > \"$CLAUDE_ENV_FILE\"; else direnv export bash > \"$CLAUDE_ENV_FILE\"; fi"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- ccweb (Claude Code on the web) の `SessionStart` フックが direnv 経由で `.envrc` を読みに行く設計だったが、fresh コンテナでは `direnv allow` が未承認のため `direnv export` が空を返し、`.devbox/nix/profile/default/bin` (osv-scanner / bun / pinact) が親 shell の `PATH` に乗らない不具合があった。
- direnv 経由をやめ、`devbox shellenv --init-hook=false` の出力を直接 `$CLAUDE_ENV_FILE` に書き出す方式へ変更。あわせて `CwdChanged` フックも remote 時のみ同じ方式に切替。
- ローカル開発側 (`CLAUDE_CODE_REMOTE != true`) は direnv ベースのまま維持。

## 検証

生成された env を source した状態で `command -v` が解決すること:

| バイナリ | 解決パス |
|---|---|
| `bun` | `.devbox/nix/profile/default/bin/bun` |
| `osv-scanner` | `.devbox/nix/profile/default/bin/osv-scanner` |
| `pinact` | `.devbox/nix/profile/default/bin/pinact` |
| `nix` | `/nix/var/nix/profiles/default/bin/nix` |
| `direnv` | (MISSING — 想定通り。依存を除去したため) |

## Test plan

- [ ] 新しい ccweb セッションを開始し、`which osv-scanner` / `which bun` / `which pinact` がそれぞれ `.devbox/nix/profile/default/bin/...` に解決されることを確認
- [ ] `osv-scanner scan source -r .` がネットワーク policy 内で動くことを確認 (`api.osv.dev` が許可済みなら通常モード、未許可なら `--offline-vulnerabilities --download-offline-databases` 併用)
- [ ] ローカル (`devbox shell`) 開発時の `direnv` ベース動作が回帰していないこと

## 補足

副次効果として `devbox global add direnv` のネットワーク待ちと外部ツール依存が SessionStart から消えるため、コンテナ起動も僅かに高速化する。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDdJuSbPd3uJhUcUBtU385)_