### PR TITLE
docs: add special cases for bun and dependency overrides

### DIFF
--- a/.claude/skills/update-dependencies/SKILL.md
+++ b/.claude/skills/update-dependencies/SKILL.md
@@ -100,21 +100,21 @@ Packages classified as Individual (both originally Individual and those promoted
 
 ## Special cases
 
-### Updating bun itself
+### Updating Bun itself
 
-When updating bun, keep all of the following in sync to the same version in the same commit:
+When updating Bun, update all of the following to the same version in a single commit:
 
 - `devbox.json` — `packages[].bun@X.Y.Z`
 - `package.json` (root) — `packageManager: "bun@X.Y.Z"`
-- `package.json` (each workspace) — `devDependencies["@types/bun"]`
+- `package.json` (each workspace) — `devDependencies["@types/bun"]: "X.Y.Z"`
 
-GitHub Actions does **not** need to be updated: `oven-sh/setup-bun` auto-detects the version from the root `package.json` `packageManager` field when `bun-version` is omitted. Do not add `bun-version` to workflows.
+The `bun-version` input of `oven-sh/setup-bun` does **not** need to be set: the action auto-detects the version from the root `package.json` `packageManager` field when `bun-version` is omitted. Do not add `bun-version` to workflows.
 
-### `overrides` / `resolutions`
+### `overrides`
 
-Do not use `overrides` (or `resolutions`) as a default remediation strategy. Resolve issues by updating the direct dependency whenever possible. Use `overrides` only when **both** of the following hold:
+Do not use `overrides` (`resolutions` in Yarn) as a default remediation strategy. Resolve issues by updating the direct dependency whenever possible. Use `overrides` only when **both** of the following apply:
 
 1. The issue cannot be resolved by updating a direct dependency (e.g., the upstream maintainer has not released a fix yet).
 2. A critical (severe) vulnerability has been reported against the transitive dependency.
 
-When `overrides` is used exceptionally, record the rationale (linked advisory, why a direct update is not viable, and removal conditions) in the PR description.
+When `overrides` is used as an exception, document the rationale (linked advisory, why a direct update is not viable, and removal conditions) in the PR description.

--- a/.claude/skills/update-dependencies/SKILL.md
+++ b/.claude/skills/update-dependencies/SKILL.md
@@ -107,7 +107,8 @@ When updating bun, keep all of the following in sync to the same version in the 
 - `devbox.json` — `packages[].bun@X.Y.Z`
 - `package.json` (root) — `packageManager: "bun@X.Y.Z"`
 - `package.json` (each workspace) — `devDependencies["@types/bun"]`
-- `.github/workflows/*.yml` — `with.bun-version` for every `oven-sh/setup-bun` step
+
+GitHub Actions does **not** need to be updated: `oven-sh/setup-bun` auto-detects the version from the root `package.json` `packageManager` field when `bun-version` is omitted. Do not add `bun-version` to workflows.
 
 ### `overrides` / `resolutions`
 

--- a/.claude/skills/update-dependencies/SKILL.md
+++ b/.claude/skills/update-dependencies/SKILL.md
@@ -97,3 +97,18 @@ Packages classified as Individual (both originally Individual and those promoted
   - Title: `[Package Name] from vA to vB`
   - Body: error details, the upstream change causing the impact, affected project code or behavior, and approaches attempted.
   - After creating the Issue, create a Draft PR and include a link to the Issue in its description.
+
+## Special cases
+
+### Updating bun itself
+
+When updating bun, keep `devbox.json` (`packages[].bun@X.Y.Z`) and `package.json` (`packageManager: "bun@X.Y.Z"`) in sync. Both must reference the same version in the same commit.
+
+### `overrides` / `resolutions`
+
+Do not use `overrides` (or `resolutions`) as a default remediation strategy. Resolve issues by updating the direct dependency whenever possible. Use `overrides` only when **both** of the following hold:
+
+1. The issue cannot be resolved by updating a direct dependency (e.g., the upstream maintainer has not released a fix yet).
+2. A critical (severe) vulnerability has been reported against the transitive dependency.
+
+When `overrides` is used exceptionally, record the rationale (linked advisory, why a direct update is not viable, and removal conditions) in the PR description.

--- a/.claude/skills/update-dependencies/SKILL.md
+++ b/.claude/skills/update-dependencies/SKILL.md
@@ -102,7 +102,12 @@ Packages classified as Individual (both originally Individual and those promoted
 
 ### Updating bun itself
 
-When updating bun, keep `devbox.json` (`packages[].bun@X.Y.Z`) and `package.json` (`packageManager: "bun@X.Y.Z"`) in sync. Both must reference the same version in the same commit.
+When updating bun, keep all of the following in sync to the same version in the same commit:
+
+- `devbox.json` — `packages[].bun@X.Y.Z`
+- `package.json` (root) — `packageManager: "bun@X.Y.Z"`
+- `package.json` (each workspace) — `devDependencies["@types/bun"]`
+- `.github/workflows/*.yml` — `with.bun-version` for every `oven-sh/setup-bun` step
 
 ### `overrides` / `resolutions`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
-        with:
-          bun-version: "1.3.11"
       - run: bun install --frozen-lockfile
       - run: bun run --bun typecheck
       - run: bun run --bun test
@@ -27,8 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
-        with:
-          bun-version: "1.3.11"
       - run: bun install --frozen-lockfile
       # Cache Playwright browser binaries (~280MB chromium). Key on lockfile
       # so cache invalidates whenever @playwright/test version changes.

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
-        with:
-          bun-version: "1.3.11"
       - run: bun install --frozen-lockfile
       - run: bun run --filter 'gm-assistant-bot-frontend' --bun build
       - name: Copy index.html to 404.html for SPA routing


### PR DESCRIPTION
## 概要

`update-dependencies` スキルに、依存関係更新時の2つの特殊ケースに関する方針を追記する。あわせて、判明した既存ワークフローの冗長な記述をクリーンアップする。

## 変更内容

### スキル: bun 本体を更新するときの同期対象

bun を更新する際は、以下を **同一コミット内で同一バージョンに揃える** ことを明文化:

- `devbox.json` の `packages[].bun@X.Y.Z`
- root `package.json` の `packageManager: "bun@X.Y.Z"`
- 各ワークスペース `package.json` の `devDependencies["@types/bun"]`

GitHub Actions の `oven-sh/setup-bun` は `bun-version` 未指定時に `package.json` の `packageManager` フィールドから自動検出するため、ワークフロー側での `bun-version` 指定は不要（むしろ同期漏れの原因になるため禁止）であることを明記。

### スキル: `overrides` の利用方針

`overrides`（Yarn の `resolutions`）はデフォルトの是正手段としては使わない。以下の **両方** を満たす場合に限り例外的に使用:

1. 直接依存の更新で問題を解決できない（例: 上流がまだ修正をリリースしていない）
2. 当該推移的依存に重大な脆弱性が報告されている

例外的に使用した場合は、根拠（リンクされた advisory・直接更新が不可な理由・解除条件）を PR description に記録する。

### ワークフロー: setup-bun の `bun-version` 明示を削除

上記の調査結果に基づき、`.github/workflows/ci.yml` と `.github/workflows/deploy-frontend.yml` の `setup-bun` ステップから冗長な `bun-version: "1.3.11"` を削除。`package.json` の `packageManager` を Source of Truth とする。

## テスト計画

- [ ] CI（typecheck / test / lint）がパスすること
- [ ] VRT ジョブが従来通り bun 1.3.11 で動作すること（`packageManager` から自動検出）
- [ ] Deploy Frontend ワークフローが（main マージ後に）正常に動作すること

https://claude.ai/code/session_01M65hoGzoKn8GsxcoGMzizJ