### PR TITLE
fix(deps): hono を 4.12.18 から 4.12.23 に更新（セキュリティ修正）

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,7 @@
     "@discordjs/rest": "2.6.1",
     "@hono/zod-validator": "0.8.0",
     "discord-api-types": "0.38.48",
-    "hono": "4.12.18",
+    "hono": "4.12.23",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@discordjs/rest": "2.6.1",
         "@hono/zod-validator": "0.8.0",
         "discord-api-types": "0.38.48",
-        "hono": "4.12.18",
+        "hono": "4.12.23",
         "zod": "4.4.3",
       },
       "devDependencies": {
@@ -44,7 +44,7 @@
         "daisyui": "5.5.20",
         "dexie": "4.4.3",
         "dexie-react-hooks": "4.4.0",
-        "hono": "4.12.18",
+        "hono": "4.12.23",
         "nanoid": "5.1.11",
         "react": "19.2.6",
         "react-dom": "19.2.6",
@@ -811,7 +811,7 @@
 
     "headers-polyfill": ["headers-polyfill@5.0.1", "", { "dependencies": { "@types/set-cookie-parser": "^2.4.10", "set-cookie-parser": "^3.0.1" } }, "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA=="],
 
-    "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
+    "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
@@ -1111,13 +1111,13 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
-    "@jridgewell/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
     "@discordjs/rest/discord-api-types": ["discord-api-types@0.38.47", "", {}, "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA=="],
 
     "@discordjs/util/discord-api-types": ["discord-api-types@0.38.47", "", {}, "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA=="],
+
+    "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@jridgewell/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "daisyui": "5.5.20",
     "dexie": "4.4.3",
     "dexie-react-hooks": "4.4.0",
-    "hono": "4.12.18",
+    "hono": "4.12.23",
     "nanoid": "5.1.11",
     "react": "19.2.6",
     "react-dom": "19.2.6",


### PR DESCRIPTION
## 概要

`hono` をセキュリティ修正のため更新しました。`backend` と `frontend` の両方で直接依存しています。

| パッケージ | 変更前 | 変更後 |
| --- | --- | --- |
| hono (backend) | 4.12.18 | 4.12.23 |
| hono (frontend) | 4.12.18 | 4.12.23 |

## 修正されるアドバイザリ（4件・いずれも moderate）

- **GHSA-xrhx-7g5j-rcj5** — 非正規な IPv6 アドレスに対する IP 制限バイパス（`ipRestriction` ミドルウェア）
- **GHSA-3hrh-pfw6-9m5x** — Cookie ヘルパーが `sameSite`/`priority` をサニタイズせず Set-Cookie インジェクションを許す（`setCookie`）
- **GHSA-f577-qrjj-4474** — JWT ミドルウェアが Bearer 以外の Authorization スキームを受け入れる（`jwt` ミドルウェア）
- **GHSA-2gcr-mfcq-wcc3** — `app.mount()` が未デコードのパスでプレフィックスを除去し、パーセントエンコードされたパスを誤ルーティングする

## 該当 API の利用状況（調査結果）

リポジトリ全体（特に backend）を調査した結果、**4件の脆弱性が対象とする API はいずれも本リポジトリでは未使用**でした。

- `ipRestriction` — 利用なし
- `setCookie` / `getCookie` / `deleteCookie` — 利用なし
- `jwt` ミドルウェア — 利用なし（使用しているのは `@hono/zod-validator` のみで本件とは無関係）
- `app.mount()` — 利用なし

したがって本更新は **予防的（precautionary）** な対応です。実際の攻撃面はありませんが、依存の健全性とサプライチェーン保護の観点から、セキュリティパッチを適用します。

## 変更内容

- `backend/package.json`: `hono` を `4.12.18` → `4.12.23`（固定バージョン）
- `frontend/package.json`: `hono` を `4.12.18` → `4.12.23`（固定バージョン）
- `bun install` により `bun.lock` を更新

## 検証

パッチレベルの更新のため、コード変更なしで全チェックが通過しました。

- ✅ `bun run --bun format`
- ✅ `bun run --bun test`（backend / frontend ともに pass、frontend 252 tests pass / 0 fail）
- ✅ `bun run --bun typecheck`（0 errors）
- ✅ `bun run --bun lint`（0 errors）
- ✅ `bun run knip`（エラーなし）

## 未対応事項の根拠

なし。該当 API は未使用のためコード側の追加対応は不要で、バージョン更新のみで完結しています。

https://claude.ai/code/session_018MQuTE4AaPPkmtScdpiNgZ

---
_Generated by [Claude Code](https://claude.ai/code/session_018MQuTE4AaPPkmtScdpiNgZ)_