### PR TITLE
feat(flow): ステップツリーの Zod スキーマを追加 (Phase 0 PR1/3)

### DIFF
--- a/frontend/src/flow/schema.test.ts
+++ b/frontend/src/flow/schema.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+
+import { FlowDataSchema, StepSchema } from "./schema";
+
+const sendMessageStep = (overrides: Record<string, unknown> = {}) => ({
+  id: "step-send",
+  type: "SendMessage",
+  title: "メッセージを送信する",
+  channelTargets: [{ type: "channelName", value: "general" }],
+  messages: [{ content: "hello", attachments: [] }],
+  ...overrides,
+});
+
+const arm = (id: string, overrides: Record<string, unknown> = {}) => ({
+  id,
+  label: `枝${id}`,
+  steps: [],
+  ...overrides,
+});
+
+const rule = (id: string) => ({
+  type: "rule",
+  id,
+  flagKey: "chapter",
+  operator: "equals",
+  value: "1",
+});
+
+const branchStep = (overrides: Record<string, unknown> = {}) => ({
+  id: "step-branch",
+  type: "Branch",
+  title: "条件分岐",
+  mode: "auto",
+  branches: [arm("a", { condition: rule("r1") }), arm("b")],
+  ...overrides,
+});
+
+const flowData = (steps: unknown[]): unknown => ({
+  version: 1,
+  sections: [{ id: "sec-1", title: "セットアップ", steps }],
+});
+
+describe("FlowDataSchema", () => {
+  test("セクション + 線形ステップを受理し、共通フィールドのデフォルトを補完する", () => {
+    const parsed = FlowDataSchema.parse(flowData([sendMessageStep()]));
+
+    const step = parsed.sections[0].steps[0];
+    expect(step.memo).toBe("");
+    expect(step.autoAdvance).toBe(false);
+    expect(step.executedAt).toBeUndefined();
+    expect(parsed.sections[0].memo).toBe("");
+    expect(parsed.sections[0].collapsed).toBe(false);
+  });
+
+  test("JSON 経由の executedAt (ISO文字列) を Date に復元する", () => {
+    const data = FlowDataSchema.parse(
+      flowData([sendMessageStep({ executedAt: new Date("2026-06-12T00:00:00Z") })]),
+    );
+    const roundTripped = FlowDataSchema.parse(JSON.parse(JSON.stringify(data)));
+
+    expect(roundTripped.sections[0].steps[0].executedAt).toEqual(new Date("2026-06-12T00:00:00Z"));
+  });
+
+  test("version が 1 以外なら拒否する", () => {
+    const result = FlowDataSchema.safeParse({ version: 2, sections: [] });
+    expect(result.success).toBe(false);
+  });
+
+  test("未知のステップ型を拒否する", () => {
+    const result = FlowDataSchema.safeParse(flowData([sendMessageStep({ type: "Unknown" })]));
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("StepSchema (Branch)", () => {
+  test("分岐の中に分岐をネストでき、JSON 往復後も parse できる", () => {
+    const nested = branchStep({
+      id: "outer",
+      branches: [
+        arm("a", {
+          condition: rule("r1"),
+          steps: [branchStep({ id: "inner" }), sendMessageStep()],
+        }),
+        arm("b"),
+      ],
+    });
+    const parsed = StepSchema.parse(JSON.parse(JSON.stringify(nested)));
+
+    if (parsed.type !== "Branch") throw new Error("Branch であるべき");
+    expect(parsed.matchMode).toBe("first");
+    const innerSteps = parsed.branches[0].steps;
+    expect(innerSteps[0].type).toBe("Branch");
+    expect(innerSteps[1].type).toBe("SendMessage");
+  });
+
+  test("auto モード: 条件なし枝 (デフォルト枝) は末尾の1つだけ許す", () => {
+    const defaultNotLast = branchStep({
+      branches: [arm("a"), arm("b", { condition: rule("r1") })],
+    });
+    expect(StepSchema.safeParse(defaultNotLast).success).toBe(false);
+
+    const twoDefaults = branchStep({
+      branches: [arm("a", { condition: rule("r1") }), arm("b"), arm("c")],
+    });
+    expect(StepSchema.safeParse(twoDefaults).success).toBe(false);
+
+    const defaultLast = branchStep({
+      branches: [arm("a", { condition: rule("r1") }), arm("b")],
+    });
+    expect(StepSchema.safeParse(defaultLast).success).toBe(true);
+  });
+
+  test("select モード: 枝に条件を持てない", () => {
+    const invalid = branchStep({
+      mode: "select",
+      branches: [arm("a", { condition: rule("r1") }), arm("b")],
+    });
+    expect(StepSchema.safeParse(invalid).success).toBe(false);
+
+    const valid = branchStep({ mode: "select", flagName: "route", branches: [arm("a"), arm("b")] });
+    expect(StepSchema.safeParse(valid).success).toBe(true);
+  });
+
+  test("枝が空の分岐を拒否する", () => {
+    expect(StepSchema.safeParse(branchStep({ branches: [] })).success).toBe(false);
+  });
+
+  test("条件ツリー: グループの children が空なら拒否する", () => {
+    const emptyGroup = branchStep({
+      branches: [
+        arm("a", { condition: { type: "group", id: "g1", logic: "and", children: [] } }),
+        arm("b"),
+      ],
+    });
+    expect(StepSchema.safeParse(emptyGroup).success).toBe(false);
+  });
+});

--- a/frontend/src/flow/schema.ts
+++ b/frontend/src/flow/schema.ts
@@ -1,0 +1,300 @@
+import z from "zod";
+
+import type { ConditionNode } from "@/components/Node/utils/evaluateCondition";
+
+import { DynamicValueSchema } from "@/components/Node/utils/DynamicValue";
+import { MessageBlockSchema } from "@/components/Node/utils/messageSchema";
+
+// ステップツリー型データモデル (issue #182 / #183)。
+// reactFlowData (ノード+エッジ+座標) を置き換える新表現で、
+// Section[] > Step[] のネスト JSON を丸ごと保存する。座標・viewport は持たない。
+
+// ---- 条件ツリー (旧 ConditionalBranchNode と同形。型は evaluateCondition と共有) ----
+
+const RuleNodeSchema = z.object({
+  type: z.literal("rule"),
+  id: z.string(),
+  flagKey: z.string(),
+  operator: z.enum(["equals", "notEquals", "contains", "exists", "notExists"]),
+  value: z.string(),
+  valueType: z.enum(["literal", "flag"]).default("literal"),
+});
+
+const ConditionNodeSchema: z.ZodType<ConditionNode> = z.union([
+  RuleNodeSchema,
+  z.object({
+    type: z.literal("group"),
+    id: z.string(),
+    logic: z.enum(["and", "or"]),
+    children: z.lazy(() => ConditionNodeSchema.array().min(1)),
+  }),
+]);
+
+// ---- ステップ共通フィールド ----
+
+const StepBaseSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  // GM 向けメモ。旧 Comment ノードの吸収先でもある
+  memo: z.string().default(""),
+  // 連鎖実行: 実行完了後に次のステップを自動実行する
+  autoAdvance: z.boolean().default(false),
+  executedAt: z.coerce.date().optional(),
+});
+
+// ---- アクション系ステップ (Discord 操作) ----
+
+const CreateRoleStepSchema = StepBaseSchema.extend({
+  type: z.literal("CreateRole"),
+  roles: z.array(z.string().nonempty().trim()),
+});
+
+const DeleteRoleStepSchema = StepBaseSchema.extend({
+  type: z.literal("DeleteRole"),
+  deleteAll: z.boolean(),
+  roleNames: z.array(z.string().trim()),
+});
+
+const CreateCategoryStepSchema = StepBaseSchema.extend({
+  type: z.literal("CreateCategory"),
+  categoryName: DynamicValueSchema,
+});
+
+const DeleteCategoryStepSchema = StepBaseSchema.extend({
+  type: z.literal("DeleteCategory"),
+});
+
+const RolePermissionSchema = z.object({
+  roleName: z.string().trim(),
+  canWrite: z.boolean(),
+});
+
+const CreateChannelStepSchema = StepBaseSchema.extend({
+  type: z.literal("CreateChannel"),
+  channels: z.array(
+    z.object({
+      name: z.string().trim(),
+      type: z.enum(["text", "voice"]),
+      rolePermissions: z.array(RolePermissionSchema),
+    }),
+  ),
+});
+
+const DeleteChannelStepSchema = StepBaseSchema.extend({
+  type: z.literal("DeleteChannel"),
+  channelNames: z.array(z.string().trim()),
+});
+
+const ChangeChannelPermissionStepSchema = StepBaseSchema.extend({
+  type: z.literal("ChangeChannelPermission"),
+  channelName: z.string().trim(),
+  rolePermissions: z.array(RolePermissionSchema),
+});
+
+const AddRoleToRoleMembersStepSchema = StepBaseSchema.extend({
+  type: z.literal("AddRoleToRoleMembers"),
+  memberRoleName: z.string().trim(),
+  addRoleName: z.string().trim(),
+});
+
+const ChannelTargetSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("channelName"), value: z.string().trim() }),
+  z.object({ type: z.literal("flagKey"), value: z.string().trim() }),
+]);
+
+const SendMessageStepSchema = StepBaseSchema.extend({
+  type: z.literal("SendMessage"),
+  channelTargets: z.array(ChannelTargetSchema).min(1),
+  messages: z.array(MessageBlockSchema).min(1),
+});
+
+const CombinationSendMessageStepSchema = StepBaseSchema.extend({
+  type: z.literal("CombinationSendMessage"),
+  entries: z
+    .array(
+      z.object({
+        id: z.string(),
+        channelName: z.string().trim().default(""),
+        messages: z.array(MessageBlockSchema).min(1),
+        collapsed: z.boolean().default(false),
+      }),
+    )
+    .min(1),
+});
+
+const SetGameFlagStepSchema = StepBaseSchema.extend({
+  type: z.literal("SetGameFlag"),
+  flagKey: z.string().trim(),
+  flagValue: z.string().trim(),
+});
+
+// ---- ツール系ステップ (Discord 操作を伴わないフラグ操作 UI) ----
+
+const KanbanLabeledItemSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+});
+
+const KanbanStepSchema = StepBaseSchema.extend({
+  type: z.literal("Kanban"),
+  columns: z.array(KanbanLabeledItemSchema).default([]),
+  cards: z.array(KanbanLabeledItemSchema).default([]),
+  initialPlacements: z.array(z.object({ cardId: z.string(), columnId: z.string() })).default([]),
+  cardPlacements: z
+    .array(z.object({ cardId: z.string(), columnId: z.string(), movedAt: z.coerce.date() }))
+    .default([]),
+});
+
+const CounterStepSchema = StepBaseSchema.extend({
+  type: z.literal("Counter"),
+  flagKey: z.string().trim(),
+  step: z.number().int().positive().default(1),
+});
+
+const ShuffleAssignStepSchema = StepBaseSchema.extend({
+  type: z.literal("ShuffleAssign"),
+  items: z.array(z.string().min(1)).min(1),
+  targets: z.array(z.string().min(1)).min(1),
+  resultFlagPrefix: z.string().trim().min(1),
+  assignedResults: z.record(z.string(), z.array(z.string())).optional(),
+});
+
+const RandomSelectStepSchema = StepBaseSchema.extend({
+  type: z.literal("RandomSelect"),
+  items: z.array(z.string().min(1)).min(1),
+  resultFlagKey: z.string().trim().min(1),
+  selectedItem: z.string().optional(),
+});
+
+const RecordCombinationStepSchema = StepBaseSchema.extend({
+  type: z.literal("RecordCombination"),
+  config: z.object({
+    mode: z.enum(["same-set", "different-set"]),
+    allowSelfPairing: z.boolean().default(false),
+    allowDuplicates: z.boolean().default(false),
+    distinguishOrder: z.boolean().default(true),
+    allowMultipleAssignments: z.boolean().default(false),
+  }),
+  sourceOptions: z.object({
+    label: z.string().default("選択肢A"),
+    items: z.array(KanbanLabeledItemSchema),
+  }),
+  targetOptions: z
+    .object({
+      label: z.string().default("選択肢B"),
+      items: z.array(KanbanLabeledItemSchema),
+    })
+    .optional(),
+  recordedPairs: z
+    .array(
+      z.object({
+        id: z.string(),
+        sourceId: z.string(),
+        targetId: z.string(),
+        recordedAt: z.coerce.date(),
+        memo: z.string().optional(),
+      }),
+    )
+    .default([]),
+});
+
+// ---- 分岐ステップ (旧 ConditionalBranch / SelectBranch を統合) ----
+
+type BranchArm = {
+  id: string;
+  label: string;
+  // auto モードの評価条件。未指定の枝はデフォルト枝 (else) として末尾にのみ置ける
+  condition?: ConditionNode;
+  steps: Step[];
+};
+
+const BranchArmSchema: z.ZodType<BranchArm> = z.object({
+  id: z.string(),
+  label: z.string(),
+  condition: ConditionNodeSchema.optional(),
+  steps: z.lazy(() => z.array(StepSchema)),
+});
+
+const BranchStepSchema = StepBaseSchema.extend({
+  type: z.literal("Branch"),
+  // auto: 条件ツリーで自動評価 / select: GM が選択肢から選ぶ
+  mode: z.enum(["auto", "select"]),
+  // auto モード: "all" はマッチした全枝を上から順に実行してから合流する
+  matchMode: z.enum(["first", "all"]).default("first"),
+  // select モード: 選択結果を書き込むゲームフラグ名
+  flagName: z.string().default(""),
+  branches: z.array(BranchArmSchema).min(1),
+  // 実行状態: 実行された (auto) / 選択された (select) 枝の id
+  executedBranchIds: z.array(z.string()).optional(),
+});
+
+// ---- ステップ / セクション / フロー全体 ----
+
+const StepUnionSchema = z.discriminatedUnion("type", [
+  CreateRoleStepSchema,
+  DeleteRoleStepSchema,
+  CreateCategoryStepSchema,
+  DeleteCategoryStepSchema,
+  CreateChannelStepSchema,
+  DeleteChannelStepSchema,
+  ChangeChannelPermissionStepSchema,
+  AddRoleToRoleMembersStepSchema,
+  SendMessageStepSchema,
+  CombinationSendMessageStepSchema,
+  SetGameFlagStepSchema,
+  KanbanStepSchema,
+  CounterStepSchema,
+  ShuffleAssignStepSchema,
+  RandomSelectStepSchema,
+  RecordCombinationStepSchema,
+  BranchStepSchema,
+]);
+
+export const StepSchema = StepUnionSchema.superRefine((step, ctx) => {
+  if (step.type !== "Branch") return;
+
+  if (step.mode === "select") {
+    step.branches.forEach((branchArm, index) => {
+      if (branchArm.condition !== undefined) {
+        ctx.addIssue({
+          code: "custom",
+          message: "select モードの枝は条件を持てません",
+          path: ["branches", index, "condition"],
+        });
+      }
+    });
+    return;
+  }
+
+  const defaultArmIndexes = step.branches.flatMap((branchArm, index) =>
+    branchArm.condition === undefined ? [index] : [],
+  );
+  if (defaultArmIndexes.length > 1) {
+    ctx.addIssue({
+      code: "custom",
+      message: "デフォルト枝 (条件なし) は1つまでです",
+      path: ["branches"],
+    });
+  } else if (defaultArmIndexes.length === 1 && defaultArmIndexes[0] !== step.branches.length - 1) {
+    ctx.addIssue({
+      code: "custom",
+      message: "デフォルト枝 (条件なし) は末尾にのみ置けます",
+      path: ["branches", defaultArmIndexes[0]],
+    });
+  }
+});
+
+const SectionSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  memo: z.string().default(""),
+  collapsed: z.boolean().default(false),
+  steps: z.array(StepSchema),
+});
+
+export const FlowDataSchema = z.object({
+  version: z.literal(1),
+  sections: z.array(SectionSchema),
+});
+
+type Step = z.infer<typeof StepSchema>;


### PR DESCRIPTION
#183 (= #182 Phase 0) の Stacked PRs **1/3**。新ステップツリーデータモデルの Zod スキーマと境界テストを追加します(純ロジック、UI なし)。

## 内容
- `frontend/src/flow/schema.ts`
  - `FlowData = { version: 1, sections: Section[] }`、`Section` は `memo` / `collapsed` を持つ
  - ステップ共通フィールド: `id` / `title` / `memo`(Comment 吸収先)/ `autoAdvance`(連鎖実行)/ `executedAt`
  - **統合分岐ステップ** `Branch`: `mode: "auto" | "select"`、`matchMode: "first" | "all"` 保持、`branches[].steps` の `z.lazy` 再帰。条件なし枝はデフォルト枝(else)として末尾のみ許可(superRefine)
  - アクション系 11 型 + ツール系 5 型(Kanban / Counter / ShuffleAssign / RandomSelect / RecordCombination)を旧 DataSchema から移植
  - `DynamicValue` / `MessageBlock` / `ConditionNode` は既存モジュールを再利用
  - LabeledGroup → Section、Comment → memo、Blueprint → ウィザード(Phase 4)のためステップ型としては持たない
- `frontend/src/flow/schema.test.ts` — 再帰ネスト、JSON 往復(`executedAt` の Date 復元)、分岐モードの制約、デフォルト補完の境界テスト

## スタック
1. **→ このPR**: スキーマ + 型定義
2. 変換器コア(線形フロー + セクション + Comment メモ吸収)— このブランチを base に作成
3. 分岐変換(共通合流点検出 + フォールバック)

## チェック
- `bun run --bun test` 261 pass / `typecheck` / `format` / `lint` / `bun run knip` ✅

Closes しません(#183 は PR3 マージで完了)。

https://claude.ai/code/session_01MXZ1fFpAyiz7eHZvJ7tweX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXZ1fFpAyiz7eHZvJ7tweX)_