### PR TITLE
feat(flow): reactFlowData → ステップツリー変換器コア (Phase 0 PR2/3)

### DIFF
--- a/frontend/src/flow/convert.test.ts
+++ b/frontend/src/flow/convert.test.ts
@@ -263,6 +263,254 @@ describe("convertReactFlowToFlowData: 分岐ノード", () => {
   });
 });
 
+describe("convertReactFlowToFlowData: レビュー指摘の回帰", () => {
+  const group = (
+    label: string,
+    pos: { x: number; y: number },
+    size: { width: number; height: number },
+  ) => rfNode("LabeledGroup", { label }, pos, { style: size });
+  const comment = (
+    data: Record<string, unknown>,
+    pos: { x: number; y: number },
+    size = { width: 200, height: 100 },
+  ) => rfNode("Comment", data, pos, { style: size });
+
+  test("グループ内 Comment は空間的に近い別グループのステップではなく同グループのステップに付く", () => {
+    const g1 = group("G1", { x: 0, y: 0 }, { width: 400, height: 400 });
+    const g2 = group("G2", { x: 0, y: 400 }, { width: 400, height: 400 });
+    const inG1 = setFlag({ x: 50, y: 50 }, "G1ステップ");
+    const inG2 = setFlag({ x: 50, y: 420 }, "G2ステップ");
+    // Comment 中心 (150, 300) は g1 内だが、空間的には g2 のステップの方が近い
+    const c = comment({ comment: "G1向けメモ" }, { x: 50, y: 250 });
+    const { flowData } = convert([g1, g2, inG1, inG2, c]);
+
+    const g1Section = flowData.sections.find((s) => s.title === "G1");
+    const g2Section = flowData.sections.find((s) => s.title === "G2");
+    expect(g1Section?.steps[0].memo).toBe("G1向けメモ");
+    expect(g2Section?.steps[0].memo).toBe("");
+  });
+
+  test("ConditionalBranch の hasDefaultBranch:false ではデフォルト枝が付かない", () => {
+    const cond = rfNode(
+      "ConditionalBranch",
+      {
+        title: "分岐",
+        conditions: [
+          {
+            id: "c1",
+            root: { type: "rule", id: "r1", flagKey: "x", operator: "exists", value: "" },
+          },
+        ],
+        hasDefaultBranch: false,
+      },
+      { x: 0, y: 0 },
+    );
+    const { flowData } = convert([cond]);
+    const branch = flowData.sections[0].steps[0];
+    if (branch.type !== "Branch") throw new Error("Branch であるべき");
+    expect(branch.branches).toHaveLength(1);
+    expect(branch.branches.every((arm) => arm.label !== "デフォルト")).toBe(true);
+  });
+
+  test("SelectBranch: selectedValue が非マッチ / 不在のとき executedBranchIds は undefined", () => {
+    const noMatch = rfNode(
+      "SelectBranch",
+      {
+        title: "選1",
+        options: [{ id: "o1", label: "A" }],
+        flagName: "f",
+        selectedValue: "存在しない",
+      },
+      { x: 0, y: 0 },
+    );
+    const { flowData } = convert([noMatch]);
+    const b1 = flowData.sections[0].steps[0];
+    if (b1.type !== "Branch") throw new Error("Branch であるべき");
+    expect(b1.executedBranchIds).toBeUndefined();
+
+    const absent = rfNode(
+      "SelectBranch",
+      { title: "選2", options: [{ id: "o1", label: "A" }], flagName: "f" },
+      { x: 0, y: 0 },
+    );
+    const { flowData: f2 } = convert([absent]);
+    const b2 = f2.sections[0].steps[0];
+    if (b2.type !== "Branch") throw new Error("Branch であるべき");
+    expect(b2.executedBranchIds).toBeUndefined();
+  });
+
+  test("不正な ConditionalBranch data は toStepCandidate の catch でスキップし警告する (nodeId 付き)", () => {
+    const bad = rfNode(
+      "ConditionalBranch",
+      { title: "壊", conditions: "配列ではない" },
+      { x: 0, y: 0 },
+    );
+    const { flowData, warnings } = convert([bad]);
+
+    expect(flowData.sections.flatMap((s) => s.steps)).toHaveLength(0);
+    expect(
+      warnings.some((w) => w.nodeId === bad.id && w.message.includes("変換できなかった")),
+    ).toBe(true);
+  });
+
+  test("不正な SelectBranch data は toStepCandidate の catch でスキップし警告する (nodeId 付き)", () => {
+    const bad = rfNode("SelectBranch", { title: "壊", options: 5 }, { x: 0, y: 0 });
+    const { flowData, warnings } = convert([bad]);
+
+    expect(flowData.sections.flatMap((s) => s.steps)).toHaveLength(0);
+    expect(
+      warnings.some((w) => w.nodeId === bad.id && w.message.includes("変換できなかった")),
+    ).toBe(true);
+  });
+
+  test("後続ステップを持たない終端 ConditionalBranch では ⚠️ メモもフラット化警告も出ない", () => {
+    const cond = rfNode(
+      "ConditionalBranch",
+      {
+        title: "終端分岐",
+        conditions: [
+          {
+            id: "c1",
+            root: { type: "rule", id: "r1", flagKey: "x", operator: "exists", value: "" },
+          },
+        ],
+        hasDefaultBranch: true,
+      },
+      { x: 0, y: 0 },
+    );
+    // 後続はステップではない Blueprint のみ。フラット化判定はステップ宛エッジだけを数える
+    const bp = rfNode("Blueprint", { title: "BP", parameters: {} }, { x: 0, y: 300 });
+    const { flowData, warnings } = convert([cond, bp], [edge(cond, bp)]);
+
+    const branch = flowData.sections[0].steps[0];
+    if (branch.type !== "Branch") throw new Error("Branch であるべき");
+    expect(branch.memo).toBe("");
+    expect(warnings.some((w) => w.message.includes("フラット化"))).toBe(false);
+  });
+
+  test("armLabel: 条件 root 欠落の枝はラベル「条件1」にフォールバックし、デフォルト枝化を警告する", () => {
+    const cond = rfNode(
+      "ConditionalBranch",
+      { title: "壊れ分岐", conditions: [{ id: "c1", root: undefined }], hasDefaultBranch: false },
+      { x: 0, y: 0 },
+    );
+    const { flowData, warnings } = convert([cond]);
+
+    const branch = flowData.sections[0].steps[0];
+    if (branch.type !== "Branch") throw new Error("Branch であるべき");
+    expect(branch.branches[0].label).toBe("条件1");
+    // condition が undefined のままなのでデフォルト(無条件)枝に化けている
+    expect(branch.branches[0].condition).toBeUndefined();
+    const w = warnings.find((w) => w.nodeId === cond.id);
+    expect(w?.message).toContain("条件1");
+    expect(w?.message).toContain("デフォルト(無条件)枝");
+    expect(w?.message).toContain("手動で条件を再設定");
+  });
+
+  test("armLabel: 定義済みだが不正な条件 root はラベルフォールバックし error.name 付きで警告する", () => {
+    const cond = rfNode(
+      "ConditionalBranch",
+      {
+        title: "壊れ条件",
+        conditions: [{ id: "c1", root: { broken: true } }],
+        hasDefaultBranch: false,
+      },
+      { x: 0, y: 0 },
+    );
+    const { warnings } = convert([cond]);
+
+    const w = warnings.find(
+      (w) => w.nodeId === cond.id && w.message.includes("条件1を読めなかった"),
+    );
+    expect(w).toBeDefined();
+    expect(w?.message).toContain("TypeError");
+  });
+
+  test("armLabel: 正常な条件式は infix 文字列をラベルにする", () => {
+    const cond = rfNode(
+      "ConditionalBranch",
+      {
+        title: "分岐",
+        conditions: [
+          {
+            id: "c1",
+            root: { type: "rule", id: "r1", flagKey: "chapter", operator: "equals", value: "1" },
+          },
+        ],
+        hasDefaultBranch: false,
+      },
+      { x: 0, y: 0 },
+    );
+    const { flowData } = convert([cond]);
+
+    const branch = flowData.sections[0].steps[0];
+    if (branch.type !== "Branch") throw new Error("Branch であるべき");
+    expect(branch.branches[0].label).toBe('chapter eq "1"');
+  });
+
+  test("source/target が欠落した不正なエッジは警告付きで捨て、変換自体は成功する", () => {
+    const a = setFlag({ x: 0, y: 0 }, "A");
+    const b = setFlag({ x: 0, y: 100 }, "B");
+    const badEdge = { id: "bad", source: "only-source" };
+    const { flowData, warnings } = convert([a, b], [badEdge, edge(a, b)]);
+
+    expect(flowData.sections[0].steps.map((s) => s.title)).toEqual(["A", "B"]);
+    expect(
+      warnings.some((w) => w.message.includes("エッジ") && w.message.includes("読み取れ")),
+    ).toBe(true);
+  });
+
+  test("検証に失敗するステップへ吸収された Comment はメモ消失を警告に含める", () => {
+    const invalid = rfNode(
+      "ShuffleAssign",
+      { title: "壊", items: [], targets: [], resultFlagPrefix: "" },
+      { x: 0, y: 0 },
+    );
+    const c = comment({ comment: "大事なメモ" }, { x: 0, y: 120 });
+    const { flowData, warnings } = convert([invalid, c]);
+
+    expect(flowData.sections.flatMap((s) => s.steps)).toHaveLength(0);
+    const w = warnings.find((w) => w.nodeId === invalid.id);
+    expect(w?.message).toContain("失われたメモ");
+    expect(w?.message).toContain("大事なメモ");
+  });
+
+  test("ラベルが空のグループのセクションタイトルは「未分類」と区別される", () => {
+    const g = group("", { x: 0, y: 0 }, { width: 400, height: 300 });
+    const inside = setFlag({ x: 50, y: 50 }, "中");
+    const { flowData } = convert([g, inside]);
+
+    expect(flowData.sections[0].steps.map((s) => s.title)).toEqual(["中"]);
+    expect(flowData.sections[0].title).not.toBe("未分類");
+    expect(flowData.sections[0].title).toBe("グループ (無題)");
+  });
+
+  test("直接の所属ノードを持たない外側グループはラベル喪失を警告する", () => {
+    const outer = group("外側", { x: 0, y: 0 }, { width: 1000, height: 1000 });
+    const inner = group("内側", { x: 100, y: 100 }, { width: 300, height: 300 });
+    const node = setFlag({ x: 150, y: 150 }, "N");
+    const { flowData, warnings } = convert([outer, inner, node]);
+
+    // 内側グループにだけ所属する。外側はセクション化されない
+    expect(flowData.sections.map((s) => s.title)).toEqual(["内側"]);
+    expect(
+      warnings.some((w) => w.nodeId === outer.id && w.message.includes("ラベルが失われ")),
+    ).toBe(true);
+    expect(warnings.some((w) => w.nodeId === inner.id)).toBe(false);
+  });
+
+  test("Comment 本文が非文字列なら無言で捨てず警告する (空 Comment は無警告)", () => {
+    const step = setFlag({ x: 0, y: 0 }, "A");
+    const badComment = comment({ comment: { nested: true } }, { x: 0, y: 120 });
+    const emptyComment = comment({ comment: "" }, { x: 0, y: 240 });
+    const { flowData, warnings } = convert([step, badComment, emptyComment]);
+
+    expect(warnings.some((w) => w.nodeId === badComment.id)).toBe(true);
+    expect(warnings.some((w) => w.nodeId === emptyComment.id)).toBe(false);
+    expect(flowData.sections[0].steps[0].memo).toBe("");
+  });
+});
+
 describe("convertReactFlowToFlowData: Blueprint", () => {
   test("Blueprint はステップ化せず、セクション memo に内容を残して警告する", () => {
     const bp = rfNode(
@@ -285,5 +533,21 @@ describe("convertReactFlowToFlowData: Blueprint", () => {
     expect(flowData.sections[0].memo).toContain("Blueprint");
     expect(flowData.sections[0].memo).toContain("characterNames");
     expect(warnings.some((w) => w.nodeId === bp.id)).toBe(true);
+  });
+
+  test("循環参照を含む parameters でも全体はクラッシュせず、警告付きで変換が成功する", () => {
+    const params: Record<string, unknown> = { name: "x" };
+    params.self = params;
+    const bp = rfNode("Blueprint", { title: "循環", parameters: params }, { x: 0, y: 0 });
+    const step = setFlag({ x: 0, y: 200 }, "次");
+
+    const { flowData, warnings } = convert([bp, step]);
+
+    expect(flowData.version).toBe(1);
+    expect(flowData.sections.flatMap((s) => s.steps).map((s) => s.title)).toEqual(["次"]);
+    expect(
+      warnings.some((w) => w.nodeId === bp.id && w.message.includes("文字列化できませんでした")),
+    ).toBe(true);
+    expect(flowData.sections.some((s) => s.memo.includes("文字列化できませんでした"))).toBe(true);
   });
 });

--- a/frontend/src/flow/convert.test.ts
+++ b/frontend/src/flow/convert.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, test } from "bun:test";
+
+import { convertReactFlowToFlowData } from "./convert";
+
+let nodeSeq = 0;
+const rfNode = (
+  type: string,
+  data: Record<string, unknown>,
+  position: { x: number; y: number },
+  extra: Record<string, unknown> = {},
+) => ({
+  id: `${type}-${++nodeSeq}`,
+  type,
+  position,
+  data,
+  ...extra,
+});
+
+const setFlag = (position: { x: number; y: number }, title = "フラグ設定") =>
+  rfNode("SetGameFlag", { title, flagKey: "k", flagValue: "v" }, position);
+
+const edge = (source: { id: string }, target: { id: string }, sourceHandle = "source-1") => ({
+  id: `${source.id}->${target.id}`,
+  source: source.id,
+  target: target.id,
+  sourceHandle,
+});
+
+const convert = (nodes: unknown[], edges: unknown[] = []) =>
+  convertReactFlowToFlowData({ nodes, edges, viewport: { x: 0, y: 0, zoom: 1 } });
+
+describe("convertReactFlowToFlowData: 線形フロー", () => {
+  test("空グラフは空の FlowData になる", () => {
+    const { flowData, warnings } = convert([]);
+    expect(flowData).toEqual({ version: 1, sections: [] });
+    expect(warnings).toEqual([]);
+  });
+
+  test("エッジの順序に従って 1 セクションに直列化する (座標順ではない)", () => {
+    const a = setFlag({ x: 0, y: 300 }, "A");
+    const b = setFlag({ x: 0, y: 0 }, "B");
+    const c = setFlag({ x: 0, y: 150 }, "C");
+    const { flowData, warnings } = convert([b, c, a], [edge(a, b), edge(b, c)]);
+
+    expect(warnings).toEqual([]);
+    expect(flowData.sections).toHaveLength(1);
+    expect(flowData.sections[0].title).toBe("未分類");
+    expect(flowData.sections[0].steps.map((s) => s.title)).toEqual(["A", "B", "C"]);
+  });
+
+  test("複数の独立チェーンは座標 (y, x) 順に連結する", () => {
+    const a1 = setFlag({ x: 0, y: 200 }, "A1");
+    const a2 = setFlag({ x: 100, y: 200 }, "A2");
+    const b1 = setFlag({ x: 0, y: 0 }, "B1");
+    const { flowData } = convert([a1, a2, b1], [edge(a1, a2)]);
+
+    expect(flowData.sections[0].steps.map((s) => s.title)).toEqual(["B1", "A1", "A2"]);
+  });
+
+  test("ステップの id / executedAt / ペイロードを引き継ぎ、autoAdvance は false になる", () => {
+    const node = rfNode(
+      "SendMessage",
+      {
+        title: "送信",
+        executedAt: "2026-06-01T00:00:00.000Z",
+        channelTargets: [{ type: "channelName", value: "general" }],
+        messages: [{ content: "hi", attachments: [] }],
+      },
+      { x: 0, y: 0 },
+    );
+    const { flowData } = convert([node]);
+
+    const step = flowData.sections[0].steps[0];
+    expect(step.id).toBe(node.id);
+    expect(step.type).toBe("SendMessage");
+    expect(step.executedAt).toEqual(new Date("2026-06-01T00:00:00.000Z"));
+    expect(step.autoAdvance).toBe(false);
+  });
+
+  test("title が無いノードは型名でフォールバックする", () => {
+    const node = rfNode("SetGameFlag", { flagKey: "k", flagValue: "v" }, { x: 0, y: 0 });
+    const { flowData } = convert([node]);
+    expect(flowData.sections[0].steps[0].title).toBe("SetGameFlag");
+  });
+
+  test("未知のノード型はスキップして警告を返す", () => {
+    const known = setFlag({ x: 0, y: 0 });
+    const unknown = rfNode("Mystery", {}, { x: 0, y: 100 });
+    const { flowData, warnings } = convert([known, unknown]);
+
+    expect(flowData.sections[0].steps).toHaveLength(1);
+    expect(warnings.some((w) => w.nodeId === unknown.id)).toBe(true);
+  });
+});
+
+describe("convertReactFlowToFlowData: 異常系", () => {
+  test("循環した接続でも全ノードを出力し、警告を返す", () => {
+    const a = setFlag({ x: 0, y: 0 }, "A");
+    const b = setFlag({ x: 0, y: 100 }, "B");
+    const { flowData, warnings } = convert([a, b], [edge(a, b), edge(b, a)]);
+
+    expect(flowData.sections[0].steps.map((s) => s.title)).toEqual(["A", "B"]);
+    expect(warnings.some((w) => w.message.includes("循環"))).toBe(true);
+  });
+
+  test("読み取れないノードはスキップして警告を返す", () => {
+    const { flowData, warnings } = convert([{ id: "broken" }, setFlag({ x: 0, y: 0 }, "A")]);
+
+    expect(flowData.sections[0].steps.map((s) => s.title)).toEqual(["A"]);
+    expect(warnings).toHaveLength(1);
+  });
+
+  test("新スキーマの検証に失敗するノードはスキップして警告を返す", () => {
+    const invalid = rfNode(
+      "ShuffleAssign",
+      { title: "壊", items: [], targets: [], resultFlagPrefix: "" },
+      { x: 0, y: 0 },
+    );
+    const ok = setFlag({ x: 0, y: 100 }, "A");
+    const { flowData, warnings } = convert([invalid, ok], [edge(invalid, ok)]);
+
+    expect(flowData.sections[0].steps.map((s) => s.title)).toEqual(["A"]);
+    expect(warnings.some((w) => w.nodeId === invalid.id)).toBe(true);
+  });
+});
+
+describe("convertReactFlowToFlowData: セクション (LabeledGroup)", () => {
+  const group = (label: string, x: number, y: number, width: number, height: number) =>
+    rfNode("LabeledGroup", { label }, { x, y }, { style: { width, height } });
+
+  test("グループ内のノードはグループ名のセクションへ、外は「未分類」へ", () => {
+    const g = group("第1章", 0, 0, 400, 300);
+    const inside = setFlag({ x: 50, y: 50 }, "中");
+    const outside = setFlag({ x: 1000, y: 1000 }, "外");
+    const { flowData } = convert([g, inside, outside], [edge(inside, outside)]);
+
+    expect(flowData.sections.map((s) => s.title)).toEqual(["第1章", "未分類"]);
+    expect(flowData.sections[0].steps.map((s) => s.title)).toEqual(["中"]);
+    expect(flowData.sections[1].steps.map((s) => s.title)).toEqual(["外"]);
+  });
+
+  test("実行順でグループが分断される場合はセクションを分割して警告する", () => {
+    const g = group("章", 0, 0, 400, 1000);
+    const in1 = setFlag({ x: 50, y: 50 }, "中1");
+    const out = setFlag({ x: 1000, y: 100 }, "外");
+    const in2 = setFlag({ x: 50, y: 500 }, "中2");
+    const { flowData, warnings } = convert([g, in1, out, in2], [edge(in1, out), edge(out, in2)]);
+
+    expect(flowData.sections.map((s) => s.title)).toEqual(["章", "未分類", "章"]);
+    expect(warnings.some((w) => w.nodeId === g.id)).toBe(true);
+  });
+
+  test("ネストしたグループは内側のグループを優先する", () => {
+    const outer = group("外側", 0, 0, 1000, 1000);
+    const inner = group("内側", 100, 100, 300, 300);
+    const node = setFlag({ x: 150, y: 150 }, "N");
+    const { flowData } = convert([outer, inner, node]);
+
+    expect(flowData.sections[0].title).toBe("内側");
+  });
+});
+
+describe("convertReactFlowToFlowData: Comment の吸収", () => {
+  const comment = (text: string, x: number, y: number) =>
+    rfNode("Comment", { comment: text }, { x, y }, { style: { width: 200, height: 100 } });
+
+  test("最近接ステップの memo に転記し、複数 Comment は連結する", () => {
+    const near = setFlag({ x: 0, y: 0 }, "近");
+    const far = setFlag({ x: 2000, y: 2000 }, "遠");
+    const c1 = comment("メモ1", 0, 120);
+    const c2 = comment("メモ2", 0, 260);
+    const { flowData } = convert([near, far, c1, c2], [edge(near, far)]);
+
+    const steps = flowData.sections[0].steps;
+    expect(steps[0].memo).toBe("メモ1\n\nメモ2");
+    expect(steps[1].memo).toBe("");
+  });
+
+  test("グループ内にステップが無い Comment はセクションの memo へ", () => {
+    const g = rfNode(
+      "LabeledGroup",
+      { label: "導入" },
+      { x: 0, y: 0 },
+      {
+        style: { width: 400, height: 300 },
+      },
+    );
+    const c = comment("グループ用メモ", 50, 50);
+    const far = setFlag({ x: 5000, y: 5000 }, "遠");
+    const { flowData } = convert([g, c, far]);
+
+    const introSection = flowData.sections.find((s) => s.title === "導入");
+    expect(introSection?.memo).toBe("グループ用メモ");
+    expect(flowData.sections.flatMap((s) => s.steps).every((s) => s.memo === "")).toBe(true);
+  });
+});
+
+describe("convertReactFlowToFlowData: 分岐ノード", () => {
+  test("SelectBranch は select モードの分岐ステップになり、後続は直列のまま", () => {
+    const select = rfNode(
+      "SelectBranch",
+      {
+        title: "ルート選択",
+        options: [
+          { id: "o1", label: "平和" },
+          { id: "o2", label: "戦闘" },
+        ],
+        flagName: "route",
+        selectedValue: "戦闘",
+      },
+      { x: 0, y: 0 },
+    );
+    const next = setFlag({ x: 0, y: 200 }, "次");
+    const { flowData, warnings } = convert([select, next], [edge(select, next)]);
+
+    expect(warnings).toEqual([]);
+    const [branch, after] = flowData.sections[0].steps;
+    if (branch.type !== "Branch") throw new Error("Branch であるべき");
+    expect(branch.mode).toBe("select");
+    expect(branch.flagName).toBe("route");
+    expect(branch.branches.map((b) => b.label)).toEqual(["平和", "戦闘"]);
+    expect(branch.executedBranchIds).toEqual(["o2"]);
+    expect(after.title).toBe("次");
+  });
+
+  test("ConditionalBranch は auto モードに変換し、後続はフラット化 + 警告 (ネスト化は PR3)", () => {
+    const cond = rfNode(
+      "ConditionalBranch",
+      {
+        title: "章で分岐",
+        conditions: [
+          {
+            id: "c1",
+            root: { type: "rule", id: "r1", flagKey: "chapter", operator: "equals", value: "1" },
+          },
+        ],
+        hasDefaultBranch: true,
+        matchMode: "all",
+        evaluatedConditionIds: ["c1"],
+      },
+      { x: 0, y: 0 },
+    );
+    const left = setFlag({ x: -100, y: 200 }, "枝1側");
+    const right = setFlag({ x: 100, y: 250 }, "デフォルト側");
+    const { flowData, warnings } = convert(
+      [cond, left, right],
+      [edge(cond, left, "source-cond-c1"), edge(cond, right, "source-default")],
+    );
+
+    const steps = flowData.sections[0].steps;
+    const branch = steps[0];
+    if (branch.type !== "Branch") throw new Error("Branch であるべき");
+    expect(branch.mode).toBe("auto");
+    expect(branch.matchMode).toBe("all");
+    expect(branch.executedBranchIds).toEqual(["c1"]);
+    expect(branch.branches).toHaveLength(2);
+    expect(branch.branches[0].condition).toBeDefined();
+    expect(branch.branches[1].condition).toBeUndefined();
+    expect(branch.branches.every((b) => b.steps.length === 0)).toBe(true);
+    expect(steps.map((s) => s.title)).toEqual(["章で分岐", "枝1側", "デフォルト側"]);
+    expect(warnings.some((w) => w.nodeId === cond.id)).toBe(true);
+    expect(branch.memo).toContain("⚠️");
+  });
+});
+
+describe("convertReactFlowToFlowData: Blueprint", () => {
+  test("Blueprint はステップ化せず、セクション memo に内容を残して警告する", () => {
+    const bp = rfNode(
+      "Blueprint",
+      {
+        title: "基本セット",
+        parameters: {
+          characterNames: ["A", "B"],
+          voiceChannelCount: 2,
+          categoryName: "cat",
+          sharedTextChannels: [],
+        },
+      },
+      { x: 0, y: 0 },
+    );
+    const next = setFlag({ x: 0, y: 200 }, "次");
+    const { flowData, warnings } = convert([bp, next], [edge(bp, next)]);
+
+    expect(flowData.sections[0].steps.map((s) => s.title)).toEqual(["次"]);
+    expect(flowData.sections[0].memo).toContain("Blueprint");
+    expect(flowData.sections[0].memo).toContain("characterNames");
+    expect(warnings.some((w) => w.nodeId === bp.id)).toBe(true);
+  });
+});

--- a/frontend/src/flow/convert.ts
+++ b/frontend/src/flow/convert.ts
@@ -1,0 +1,391 @@
+import z from "zod";
+
+import type { ConditionNode } from "@/components/Node/utils/evaluateCondition";
+
+import { conditionToInfix } from "@/components/Node/utils/evaluateCondition";
+
+import type { FlowData, Step } from "./schema";
+
+import { FlowDataSchema, StepSchema } from "./schema";
+
+// reactFlowData (グラフ) → FlowData (ステップツリー) のベストエフォート変換器。
+// 変換しきれない構造は捨てずにフラット化し、⚠️ メモと警告で手直しを促す。
+
+type ConversionWarning = {
+  message: string;
+  nodeId?: string;
+};
+
+const RFNodeSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  position: z.object({ x: z.number(), y: z.number() }),
+  data: z.record(z.string(), z.unknown()).default({}),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  measured: z
+    .object({ width: z.number().optional(), height: z.number().optional() })
+    .partial()
+    .optional(),
+  style: z
+    .object({ width: z.number().optional(), height: z.number().optional() })
+    .partial()
+    .optional(),
+});
+type RFNode = z.infer<typeof RFNodeSchema>;
+
+const RFEdgeSchema = z.object({
+  source: z.string(),
+  target: z.string(),
+  sourceHandle: z.string().nullish(),
+});
+type RFEdge = z.infer<typeof RFEdgeSchema>;
+
+const ConvertInputSchema = z.object({
+  nodes: z.array(z.unknown()).default([]),
+  edges: z.array(z.unknown()).default([]),
+});
+
+// 旧グラフでステップへ変換する対象 (LabeledGroup / Comment / Blueprint を除く全ノード型)
+const STEP_NODE_TYPES = new Set([
+  "CreateRole",
+  "DeleteRole",
+  "CreateCategory",
+  "DeleteCategory",
+  "CreateChannel",
+  "DeleteChannel",
+  "ChangeChannelPermission",
+  "AddRoleToRoleMembers",
+  "SendMessage",
+  "CombinationSendMessage",
+  "SetGameFlag",
+  "Kanban",
+  "Counter",
+  "ShuffleAssign",
+  "RandomSelect",
+  "RecordCombination",
+  "ConditionalBranch",
+  "SelectBranch",
+]);
+
+const UNGROUPED = Symbol("ungrouped");
+const UNGROUPED_TITLE = "未分類";
+
+const sizeOf = (node: RFNode) => ({
+  width: node.measured?.width ?? node.width ?? node.style?.width ?? 0,
+  height: node.measured?.height ?? node.height ?? node.style?.height ?? 0,
+});
+
+const centerOf = (node: RFNode) => {
+  const { width, height } = sizeOf(node);
+  return { x: node.position.x + width / 2, y: node.position.y + height / 2 };
+};
+
+const distance = (a: RFNode, b: RFNode) => {
+  const ca = centerOf(a);
+  const cb = centerOf(b);
+  return Math.hypot(ca.x - cb.x, ca.y - cb.y);
+};
+
+const byPosition = (a: RFNode, b: RFNode) =>
+  a.position.y - b.position.y || a.position.x - b.position.x;
+
+const appendMemo = (memo: string, text: string) => (memo === "" ? text : `${memo}\n\n${text}`);
+
+// 内包判定はノードの中心点で行い、ネストしたグループは面積最小 (最内) を採用する
+function findContainingGroup(node: RFNode, groups: RFNode[]): RFNode | undefined {
+  const center = centerOf(node);
+  let innermost: RFNode | undefined;
+  let innermostArea = Number.POSITIVE_INFINITY;
+  for (const group of groups) {
+    if (group.id === node.id) continue;
+    const { width, height } = sizeOf(group);
+    const contains =
+      center.x >= group.position.x &&
+      center.x <= group.position.x + width &&
+      center.y >= group.position.y &&
+      center.y <= group.position.y + height;
+    if (contains && width * height < innermostArea) {
+      innermost = group;
+      innermostArea = width * height;
+    }
+  }
+  return innermost;
+}
+
+// エッジを尊重したトポロジカル順 (Kahn 法)。同時に実行可能なノードは座標 (y, x) 順。
+// 循環で残ったノードは座標順で末尾に足し、警告を返す。
+function orderStepNodes(
+  stepNodes: RFNode[],
+  edges: RFEdge[],
+  warnings: ConversionWarning[],
+): RFNode[] {
+  const byId = new Map(stepNodes.map((node) => [node.id, node]));
+  const outgoing = new Map<string, string[]>();
+  const inDegree = new Map<string, number>(stepNodes.map((node) => [node.id, 0]));
+  for (const edge of edges) {
+    if (!byId.has(edge.source) || !byId.has(edge.target)) continue;
+    outgoing.set(edge.source, [...(outgoing.get(edge.source) ?? []), edge.target]);
+    inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
+  }
+
+  const ready = stepNodes.filter((node) => inDegree.get(node.id) === 0).sort(byPosition);
+  const ordered: RFNode[] = [];
+  while (ready.length > 0) {
+    const node = ready.shift() as RFNode;
+    ordered.push(node);
+    const becameReady: RFNode[] = [];
+    for (const targetId of outgoing.get(node.id) ?? []) {
+      const remaining = (inDegree.get(targetId) ?? 0) - 1;
+      inDegree.set(targetId, remaining);
+      if (remaining === 0) becameReady.push(byId.get(targetId) as RFNode);
+    }
+    // 直後に実行可能になったノードを優先しつつ、複数あれば座標順で先頭に挿入する
+    ready.unshift(...becameReady.sort(byPosition));
+  }
+
+  if (ordered.length < stepNodes.length) {
+    const leftover = stepNodes.filter((node) => !ordered.includes(node)).sort(byPosition);
+    warnings.push({
+      message: `循環した接続があるため ${leftover.length} 個のノードを末尾に配置しました`,
+    });
+    ordered.push(...leftover);
+  }
+  return ordered;
+}
+
+function titleOf(node: RFNode): string {
+  const title = node.data.title;
+  return typeof title === "string" && title !== "" ? title : node.type;
+}
+
+const ConditionalBranchDataSchema = z.object({
+  conditions: z.array(z.object({ id: z.string(), root: z.unknown() })),
+  hasDefaultBranch: z.boolean().default(true),
+  matchMode: z.enum(["first", "all"]).default("first"),
+  evaluatedConditionIds: z.array(z.string()).optional(),
+});
+
+const SelectBranchDataSchema = z.object({
+  options: z.array(z.object({ id: z.string(), label: z.string() })),
+  flagName: z.string().default(""),
+  selectedValue: z.string().optional(),
+});
+
+function armLabel(root: unknown, index: number): string {
+  try {
+    return conditionToInfix(root as ConditionNode);
+  } catch {
+    return `条件${index + 1}`;
+  }
+}
+
+// ノード → ステップ候補 (parse 前の生データ)。分岐 2 種は統合 Branch 型へ再構成し、
+// それ以外は data のフィールド名が新スキーマと同じためそのまま引き継ぐ。
+function toStepCandidate(node: RFNode): Record<string, unknown> {
+  if (node.type === "ConditionalBranch") {
+    const data = ConditionalBranchDataSchema.parse(node.data);
+    return {
+      id: node.id,
+      type: "Branch",
+      title: titleOf(node),
+      executedAt: node.data.executedAt,
+      mode: "auto",
+      matchMode: data.matchMode,
+      branches: [
+        ...data.conditions.map((condition, index) => ({
+          id: condition.id,
+          label: armLabel(condition.root, index),
+          condition: condition.root,
+          steps: [],
+        })),
+        ...(data.hasDefaultBranch ? [{ id: "default", label: "デフォルト", steps: [] }] : []),
+      ],
+      executedBranchIds: data.evaluatedConditionIds,
+    };
+  }
+  if (node.type === "SelectBranch") {
+    const data = SelectBranchDataSchema.parse(node.data);
+    const selectedId = data.options.find((option) => option.label === data.selectedValue)?.id;
+    return {
+      id: node.id,
+      type: "Branch",
+      title: titleOf(node),
+      executedAt: node.data.executedAt,
+      mode: "select",
+      flagName: data.flagName,
+      branches: data.options.map((option) => ({ id: option.id, label: option.label, steps: [] })),
+      executedBranchIds: selectedId === undefined ? undefined : [selectedId],
+    };
+  }
+  return { ...node.data, id: node.id, type: node.type, title: titleOf(node) };
+}
+
+export function convertReactFlowToFlowData(input: unknown): {
+  flowData: FlowData;
+  warnings: ConversionWarning[];
+} {
+  const warnings: ConversionWarning[] = [];
+  const parsed = ConvertInputSchema.parse(input);
+
+  const nodes: RFNode[] = [];
+  for (const rawNode of parsed.nodes) {
+    const result = RFNodeSchema.safeParse(rawNode);
+    if (result.success) {
+      nodes.push(result.data);
+    } else {
+      warnings.push({ message: "ノードを読み取れなかったためスキップしました" });
+    }
+  }
+  const edges: RFEdge[] = [];
+  for (const rawEdge of parsed.edges) {
+    const result = RFEdgeSchema.safeParse(rawEdge);
+    if (result.success) edges.push(result.data);
+  }
+
+  const groups = nodes.filter((node) => node.type === "LabeledGroup");
+  const comments = nodes.filter((node) => node.type === "Comment").sort(byPosition);
+  const blueprints = nodes.filter((node) => node.type === "Blueprint");
+  const stepNodes = nodes.filter((node) => STEP_NODE_TYPES.has(node.type));
+  for (const node of nodes) {
+    if (
+      node.type !== "LabeledGroup" &&
+      node.type !== "Comment" &&
+      node.type !== "Blueprint" &&
+      !STEP_NODE_TYPES.has(node.type)
+    ) {
+      warnings.push({ nodeId: node.id, message: `未知のノード型 ${node.type} をスキップしました` });
+    }
+  }
+
+  const ordered = orderStepNodes(stepNodes, edges, warnings);
+  const groupKeyOf = (node: RFNode) => findContainingGroup(node, groups)?.id ?? UNGROUPED;
+
+  // ステップ候補を組み立て、検証に失敗したものは捨てて警告にする
+  const candidates: { node: RFNode; candidate: Record<string, unknown> }[] = [];
+  for (const node of ordered) {
+    try {
+      candidates.push({ node, candidate: toStepCandidate(node) });
+    } catch {
+      warnings.push({
+        nodeId: node.id,
+        message: `ノード「${titleOf(node)}」のデータを変換できなかったためスキップしました`,
+      });
+    }
+  }
+
+  // ConditionalBranch の後続はネスト化せずフラットに並ぶ (合流点検出は後続 PR)
+  const outgoingCount = new Map<string, number>();
+  for (const edge of edges) {
+    outgoingCount.set(edge.source, (outgoingCount.get(edge.source) ?? 0) + 1);
+  }
+  for (const { node, candidate } of candidates) {
+    if (node.type === "ConditionalBranch" && (outgoingCount.get(node.id) ?? 0) > 0) {
+      candidate.memo = appendMemo(
+        (candidate.memo as string | undefined) ?? "",
+        "⚠️ 分岐の枝を自動ネスト化できなかったため、後続ステップをフラットに並べています。枝の内容を手動で移動してください。",
+      );
+      warnings.push({
+        nodeId: node.id,
+        message: `分岐「${titleOf(node)}」の後続をフラット化しました`,
+      });
+    }
+  }
+
+  // Comment の吸収: グループ内なら同グループ内の最近接ステップ、いなければセクション memo へ。
+  // グループ外なら全ステップ中の最近接へ
+  const sectionMemos = new Map<string | typeof UNGROUPED, string>();
+  const addSectionMemo = (key: string | typeof UNGROUPED, text: string) => {
+    sectionMemos.set(key, appendMemo(sectionMemos.get(key) ?? "", text));
+  };
+  for (const comment of comments) {
+    const text = typeof comment.data.comment === "string" ? comment.data.comment : "";
+    if (text === "") continue;
+    const groupKey = groupKeyOf(comment);
+    const scope =
+      groupKey === UNGROUPED
+        ? candidates
+        : candidates.filter(({ node }) => groupKeyOf(node) === groupKey);
+    const nearest = [...scope].sort(
+      (a, b) => distance(a.node, comment) - distance(b.node, comment),
+    )[0];
+    if (nearest) {
+      nearest.candidate.memo = appendMemo(
+        (nearest.candidate.memo as string | undefined) ?? "",
+        text,
+      );
+    } else {
+      addSectionMemo(groupKey, text);
+    }
+  }
+
+  // Blueprint はウィザード (Phase 4) に移行するためステップ化せず、所属セクションの memo に残す
+  for (const blueprint of blueprints) {
+    addSectionMemo(
+      groupKeyOf(blueprint),
+      `⚠️ Blueprint「${titleOf(blueprint)}」はウィザードに移行されるためステップ化されませんでした。パラメータ: ${JSON.stringify(blueprint.data.parameters ?? {})}`,
+    );
+    warnings.push({
+      nodeId: blueprint.id,
+      message: `Blueprint「${titleOf(blueprint)}」はステップ化されませんでした`,
+    });
+  }
+
+  // 実行順を保ったまま、所属グループが切り替わるごとにセクションを区切る
+  const groupById = new Map(groups.map((group) => [group.id, group]));
+  const sectionTitle = (group: RFNode | undefined) => {
+    const label = group?.data.label;
+    return typeof label === "string" && label !== "" ? label : UNGROUPED_TITLE;
+  };
+  const sections: { id: string; title: string; memo: string; steps: Step[] }[] = [];
+  const runCount = new Map<string | typeof UNGROUPED, number>();
+  let currentKey: string | typeof UNGROUPED | null = null;
+  for (const { node, candidate } of candidates) {
+    const stepResult = StepSchema.safeParse(candidate);
+    if (!stepResult.success) {
+      warnings.push({
+        nodeId: node.id,
+        message: `ノード「${titleOf(node)}」のデータが不正なためスキップしました`,
+      });
+      continue;
+    }
+    const key = groupKeyOf(node);
+    if (key !== currentKey || sections.length === 0) {
+      currentKey = key;
+      const run = (runCount.get(key) ?? 0) + 1;
+      runCount.set(key, run);
+      const group = key === UNGROUPED ? undefined : groupById.get(key);
+      const baseId = key === UNGROUPED ? "ungrouped" : key;
+      sections.push({
+        id: run === 1 ? String(baseId) : `${String(baseId)}-${run}`,
+        title: sectionTitle(group),
+        memo: "",
+        steps: [],
+      });
+    }
+    sections.at(-1)?.steps.push(stepResult.data);
+  }
+
+  for (const [key, run] of runCount) {
+    if (run > 1 && key !== UNGROUPED) {
+      warnings.push({
+        nodeId: key,
+        message: "グループ内のステップが実行順で分断されているため、セクションを分割しました",
+      });
+    }
+  }
+
+  // セクション宛 memo (グループ内 Comment / Blueprint) を反映。該当セクションが無ければ作る
+  for (const [key, memo] of sectionMemos) {
+    const baseId = key === UNGROUPED ? "ungrouped" : key;
+    let section = sections.find((candidate) => candidate.id === String(baseId));
+    if (!section) {
+      const group = key === UNGROUPED ? undefined : groupById.get(key);
+      section = { id: String(baseId), title: sectionTitle(group), memo: "", steps: [] };
+      sections.push(section);
+    }
+    section.memo = appendMemo(section.memo, memo);
+  }
+
+  return { flowData: FlowDataSchema.parse({ version: 1, sections }), warnings };
+}

--- a/frontend/src/flow/convert.ts
+++ b/frontend/src/flow/convert.ts
@@ -16,6 +16,25 @@ type ConversionWarning = {
   nodeId?: string;
 };
 
+// Zod の検証失敗を「path: 理由」の短い要約にする。どのフィールドがなぜ落ちたか特定するため
+function summarizeIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.map((segment) => segment.toString()).join(".");
+      return path === "" ? issue.message : `${path}: ${issue.message}`;
+    })
+    .join("; ");
+}
+
+// 検証前の生オブジェクトから文字列フィールドを best-effort で取り出す (warning メッセージ用)
+function rawStringField(raw: unknown, key: string): string | undefined {
+  if (raw !== null && typeof raw === "object" && key in raw) {
+    const value = (raw as Record<string, unknown>)[key];
+    if (typeof value === "string") return value;
+  }
+  return undefined;
+}
+
 const RFNodeSchema = z.object({
   id: z.string(),
   type: z.string(),
@@ -70,6 +89,8 @@ const STEP_NODE_TYPES = new Set([
 
 const UNGROUPED = Symbol("ungrouped");
 const UNGROUPED_TITLE = "未分類";
+// ラベルが空の LabeledGroup 用。未分類 (グループ非所属) とは区別できる既定タイトル
+const UNTITLED_GROUP_TITLE = "グループ (無題)";
 
 const sizeOf = (node: RFNode) => ({
   width: node.measured?.width ?? node.width ?? node.style?.width ?? 0,
@@ -172,17 +193,49 @@ const SelectBranchDataSchema = z.object({
   selectedValue: z.string().optional(),
 });
 
-function armLabel(root: unknown, index: number): string {
+// 1 つの条件枝を Branch の arm 候補へ変換する。条件式が読めない場合はラベルを
+// 「条件N」へフォールバックしつつ、喪失内容を警告で surface する。
+function toBranchArm(
+  condition: { id: string; root: unknown },
+  index: number,
+  nodeId: string,
+  warnings: ConversionWarning[],
+): { id: string; label: string; condition: unknown; steps: never[] } {
   try {
-    return conditionToInfix(root as ConditionNode);
-  } catch {
-    return `条件${index + 1}`;
+    return {
+      id: condition.id,
+      label: conditionToInfix(condition.root as ConditionNode),
+      condition: condition.root,
+      steps: [],
+    };
+  } catch (error) {
+    // error.name を残し、ZodError 以外の想定外例外型 (TypeError 等) を後から識別可能にする
+    const errorName = error instanceof Error ? error.constructor.name : "UnknownError";
+    const detail = error instanceof Error ? error.message : String(error);
+    if (condition.root === undefined) {
+      // condition root 欠落の枝は BranchArmSchema.condition が optional なため検証を通り、
+      // 「条件なし = 無条件デフォルト(else)枝」に化ける。ラベルだけでなく意味論の変化を警告する
+      warnings.push({
+        nodeId,
+        message: `分岐の条件${
+          index + 1
+        }を読み取れなかったため、この枝はデフォルト(無条件)枝になりました。手動で条件を再設定してください (${errorName}: ${detail})`,
+      });
+    } else {
+      warnings.push({
+        nodeId,
+        message: `分岐の条件${index + 1}を読めなかったため「条件${
+          index + 1
+        }」と表示します (${errorName}: ${detail})`,
+      });
+    }
+    return { id: condition.id, label: `条件${index + 1}`, condition: condition.root, steps: [] };
   }
 }
 
 // ノード → ステップ候補 (parse 前の生データ)。分岐 2 種は統合 Branch 型へ再構成し、
 // それ以外は data のフィールド名が新スキーマと同じためそのまま引き継ぐ。
-function toStepCandidate(node: RFNode): Record<string, unknown> {
+function toStepCandidate(node: RFNode, warnings: ConversionWarning[]): Record<string, unknown> {
   if (node.type === "ConditionalBranch") {
     const data = ConditionalBranchDataSchema.parse(node.data);
     return {
@@ -193,12 +246,9 @@ function toStepCandidate(node: RFNode): Record<string, unknown> {
       mode: "auto",
       matchMode: data.matchMode,
       branches: [
-        ...data.conditions.map((condition, index) => ({
-          id: condition.id,
-          label: armLabel(condition.root, index),
-          condition: condition.root,
-          steps: [],
-        })),
+        ...data.conditions.map((condition, index) =>
+          toBranchArm(condition, index, node.id, warnings),
+        ),
         ...(data.hasDefaultBranch ? [{ id: "default", label: "デフォルト", steps: [] }] : []),
       ],
       executedBranchIds: data.evaluatedConditionIds,
@@ -234,13 +284,28 @@ export function convertReactFlowToFlowData(input: unknown): {
     if (result.success) {
       nodes.push(result.data);
     } else {
-      warnings.push({ message: "ノードを読み取れなかったためスキップしました" });
+      warnings.push({
+        nodeId: rawStringField(rawNode, "id"),
+        message: `ノードを読み取れなかったためスキップしました: ${summarizeIssues(result.error)}`,
+      });
     }
   }
   const edges: RFEdge[] = [];
   for (const rawEdge of parsed.edges) {
     const result = RFEdgeSchema.safeParse(rawEdge);
-    if (result.success) edges.push(result.data);
+    if (result.success) {
+      edges.push(result.data);
+    } else {
+      const source = rawStringField(rawEdge, "source");
+      const target = rawStringField(rawEdge, "target");
+      const endpoints =
+        source !== undefined || target !== undefined
+          ? ` (${source ?? "?"} → ${target ?? "?"})`
+          : "";
+      warnings.push({
+        message: `エッジ${endpoints}を読み取れなかったためスキップしました: ${summarizeIssues(result.error)}`,
+      });
+    }
   }
 
   const groups = nodes.filter((node) => node.type === "LabeledGroup");
@@ -265,22 +330,29 @@ export function convertReactFlowToFlowData(input: unknown): {
   const candidates: { node: RFNode; candidate: Record<string, unknown> }[] = [];
   for (const node of ordered) {
     try {
-      candidates.push({ node, candidate: toStepCandidate(node) });
-    } catch {
+      candidates.push({ node, candidate: toStepCandidate(node, warnings) });
+    } catch (error) {
+      // ZodError はデータ不整合なので best-effort スキップ。それ以外 (TypeError 等の
+      // プログラミングエラー) は握りつぶさず再 throw する
+      if (!(error instanceof z.ZodError)) throw error;
       warnings.push({
         nodeId: node.id,
-        message: `ノード「${titleOf(node)}」のデータを変換できなかったためスキップしました`,
+        message: `ノード「${titleOf(node)}」のデータを変換できなかったためスキップしました: ${summarizeIssues(error)}`,
       });
     }
   }
 
-  // ConditionalBranch の後続はネスト化せずフラットに並ぶ (合流点検出は後続 PR)
-  const outgoingCount = new Map<string, number>();
+  // ConditionalBranch の後続はネスト化せずフラットに並ぶ (合流点検出は後続 PR)。
+  // フラット化対象はステップノード宛のエッジのみ。Comment/Blueprint/未知ノード宛しか
+  // 無い終端分岐で警告・⚠️ メモが誤発火するのを防ぐ
+  const stepNodeIds = new Set(stepNodes.map((node) => node.id));
+  const stepOutgoingCount = new Map<string, number>();
   for (const edge of edges) {
-    outgoingCount.set(edge.source, (outgoingCount.get(edge.source) ?? 0) + 1);
+    if (!stepNodeIds.has(edge.target)) continue;
+    stepOutgoingCount.set(edge.source, (stepOutgoingCount.get(edge.source) ?? 0) + 1);
   }
   for (const { node, candidate } of candidates) {
-    if (node.type === "ConditionalBranch" && (outgoingCount.get(node.id) ?? 0) > 0) {
+    if (node.type === "ConditionalBranch" && (stepOutgoingCount.get(node.id) ?? 0) > 0) {
       candidate.memo = appendMemo(
         (candidate.memo as string | undefined) ?? "",
         "⚠️ 分岐の枝を自動ネスト化できなかったため、後続ステップをフラットに並べています。枝の内容を手動で移動してください。",
@@ -299,7 +371,17 @@ export function convertReactFlowToFlowData(input: unknown): {
     sectionMemos.set(key, appendMemo(sectionMemos.get(key) ?? "", text));
   };
   for (const comment of comments) {
-    const text = typeof comment.data.comment === "string" ? comment.data.comment : "";
+    const rawComment = comment.data.comment;
+    // 値は存在するが非文字列 (数値/オブジェクト等) は黙って捨てず warning にする。
+    // 欠落 (undefined) / null / 空文字は正規スキップとして無警告
+    if (rawComment !== undefined && rawComment !== null && typeof rawComment !== "string") {
+      warnings.push({
+        nodeId: comment.id,
+        message: "Comment の本文が文字列でないため取り込めませんでした",
+      });
+      continue;
+    }
+    const text = typeof rawComment === "string" ? rawComment : "";
     if (text === "") continue;
     const groupKey = groupKeyOf(comment);
     const scope =
@@ -321,9 +403,23 @@ export function convertReactFlowToFlowData(input: unknown): {
 
   // Blueprint はウィザード (Phase 4) に移行するためステップ化せず、所属セクションの memo に残す
   for (const blueprint of blueprints) {
+    // data は z.record(z.unknown()) で素通しのため、循環参照や BigInt 等で stringify が throw し得る。
+    // 1 個の壊れた Blueprint で変換全体 (収集済み warnings ごと) をクラッシュさせないよう握る
+    let parametersText: string;
+    try {
+      parametersText = JSON.stringify(blueprint.data.parameters ?? {});
+    } catch (error) {
+      parametersText = "(パラメータを文字列化できませんでした)";
+      warnings.push({
+        nodeId: blueprint.id,
+        message: `Blueprint「${titleOf(blueprint)}」のパラメータを文字列化できませんでした: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      });
+    }
     addSectionMemo(
       groupKeyOf(blueprint),
-      `⚠️ Blueprint「${titleOf(blueprint)}」はウィザードに移行されるためステップ化されませんでした。パラメータ: ${JSON.stringify(blueprint.data.parameters ?? {})}`,
+      `⚠️ Blueprint「${titleOf(blueprint)}」はウィザードに移行されるためステップ化されませんでした。パラメータ: ${parametersText}`,
     );
     warnings.push({
       nodeId: blueprint.id,
@@ -334,22 +430,31 @@ export function convertReactFlowToFlowData(input: unknown): {
   // 実行順を保ったまま、所属グループが切り替わるごとにセクションを区切る
   const groupById = new Map(groups.map((group) => [group.id, group]));
   const sectionTitle = (group: RFNode | undefined) => {
-    const label = group?.data.label;
-    return typeof label === "string" && label !== "" ? label : UNGROUPED_TITLE;
+    if (group === undefined) return UNGROUPED_TITLE;
+    const label = group.data.label;
+    return typeof label === "string" && label !== "" ? label : UNTITLED_GROUP_TITLE;
   };
   const sections: { id: string; title: string; memo: string; steps: Step[] }[] = [];
   const runCount = new Map<string | typeof UNGROUPED, number>();
+  // セクション化されたグループ。ここに載らないグループはラベルが失われるため後で警告する
+  const realizedGroupIds = new Set<string>();
   let currentKey: string | typeof UNGROUPED | null = null;
   for (const { node, candidate } of candidates) {
     const stepResult = StepSchema.safeParse(candidate);
     if (!stepResult.success) {
+      // 吸収済み Comment の memo はこのステップと共に失われるため、内容を warning に残す
+      const lostMemo =
+        typeof candidate.memo === "string" && candidate.memo !== "" ? candidate.memo : undefined;
       warnings.push({
         nodeId: node.id,
-        message: `ノード「${titleOf(node)}」のデータが不正なためスキップしました`,
+        message: `ノード「${titleOf(node)}」のデータが不正なためスキップしました: ${summarizeIssues(
+          stepResult.error,
+        )}${lostMemo === undefined ? "" : ` (失われたメモ: ${lostMemo})`}`,
       });
       continue;
     }
     const key = groupKeyOf(node);
+    if (key !== UNGROUPED) realizedGroupIds.add(key);
     if (key !== currentKey || sections.length === 0) {
       currentKey = key;
       const run = (runCount.get(key) ?? 0) + 1;
@@ -377,6 +482,7 @@ export function convertReactFlowToFlowData(input: unknown): {
 
   // セクション宛 memo (グループ内 Comment / Blueprint) を反映。該当セクションが無ければ作る
   for (const [key, memo] of sectionMemos) {
+    if (key !== UNGROUPED) realizedGroupIds.add(key);
     const baseId = key === UNGROUPED ? "ungrouped" : key;
     let section = sections.find((candidate) => candidate.id === String(baseId));
     if (!section) {
@@ -385,6 +491,18 @@ export function convertReactFlowToFlowData(input: unknown): {
       sections.push(section);
     }
     section.memo = appendMemo(section.memo, memo);
+  }
+
+  // 直接の所属ノードを持たないグループ (例: ネストの外側グループや空グループ) はセクション化
+  // されずラベルが失われる。他のスキップは全て警告される方針に合わせ、ここも warning を残す
+  for (const group of groups) {
+    if (realizedGroupIds.has(group.id)) continue;
+    const label = group.data.label;
+    const labelText = typeof label === "string" && label !== "" ? `「${label}」` : "(無題)";
+    warnings.push({
+      nodeId: group.id,
+      message: `グループ${labelText}は所属するノードが無いためセクション化されず、ラベルが失われました`,
+    });
   }
 
   return { flowData: FlowDataSchema.parse({ version: 1, sections }), warnings };

--- a/frontend/src/flow/schema.ts
+++ b/frontend/src/flow/schema.ts
@@ -297,4 +297,5 @@ export const FlowDataSchema = z.object({
   sections: z.array(SectionSchema),
 });
 
-type Step = z.infer<typeof StepSchema>;
+export type Step = z.infer<typeof StepSchema>;
+export type FlowData = z.infer<typeof FlowDataSchema>;


### PR DESCRIPTION
#183 (= #182 Phase 0) の Stacked PRs **2/3**(base: #184)。reactFlowData → FlowData のベストエフォート変換器コアを追加します。

## 内容(`frontend/src/flow/convert.ts`)
- **直列化**: Kahn 法のトポロジカル順(同時実行可能なノードは座標 y,x 順)。循環は警告付きで末尾配置
- **セクション化**: LabeledGroup の空間的内包(中心点判定、ネストは最内優先)。実行順でグループが分断される場合はセクション分割 + 警告。グループ外は「未分類」
- **Comment 吸収**(インタビュー決定事項): 最近接ステップの `memo` へ転記。グループ内にステップが無い場合はセクション `memo` へ
- **SelectBranch** → `Branch (mode: select)`。旧モデルではグラフ分岐しない(単一出力でフラグ書込のみ)ため後続は直列のまま。`selectedValue`(ラベル)→ 枝 id に解決して `executedBranchIds` へ
- **ConditionalBranch** → `Branch (mode: auto)`(matchMode / evaluatedConditionIds 保持、枝ラベルは `conditionToInfix`)。**後続のネスト化は PR3** — 本PRではフラット化 + ⚠️ メモ + 警告
- **Blueprint**: ステップ化せず(Phase 4 でウィザード化)、パラメータをセクション memo に保全 + 警告
- ベストエフォート方針: 読み取れない / 検証に失敗するノードはスキップしつつ `warnings` に収集

## チェック
- frontend 278 tests pass / `typecheck` / `format` / `lint` / `bun run knip` ✅

https://claude.ai/code/session_01MXZ1fFpAyiz7eHZvJ7tweX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXZ1fFpAyiz7eHZvJ7tweX)_