### PR TITLE
feat(flow): 分岐の合流点検出によるネスト変換 (Phase 0 PR3/3)

### DIFF
--- a/frontend/src/flow/convert.test.ts
+++ b/frontend/src/flow/convert.test.ts
@@ -223,8 +223,8 @@ describe("convertReactFlowToFlowData: 分岐ノード", () => {
     expect(after.title).toBe("次");
   });
 
-  test("ConditionalBranch は auto モードに変換し、後続はフラット化 + 警告 (ネスト化は PR3)", () => {
-    const cond = rfNode(
+  const conditionalBranch = (overrides: Record<string, unknown> = {}) =>
+    rfNode(
       "ConditionalBranch",
       {
         title: "章で分岐",
@@ -235,31 +235,217 @@ describe("convertReactFlowToFlowData: 分岐ノード", () => {
           },
         ],
         hasDefaultBranch: true,
-        matchMode: "all",
-        evaluatedConditionIds: ["c1"],
+        matchMode: "first",
+        ...overrides,
       },
       { x: 0, y: 0 },
     );
-    const left = setFlag({ x: -100, y: 200 }, "枝1側");
-    const right = setFlag({ x: 100, y: 250 }, "デフォルト側");
+
+  const getBranch = (step: { type: string }) => {
+    if (step.type !== "Branch") throw new Error("Branch であるべき");
+    return step as Extract<
+      ReturnType<
+        typeof convertReactFlowToFlowData
+      >["flowData"]["sections"][number]["steps"][number],
+      { type: "Branch" }
+    >;
+  };
+
+  test("ConditionalBranch は枝の内容をネストし、合流点以降は分岐の後に続く", () => {
+    const cond = conditionalBranch({ matchMode: "all", evaluatedConditionIds: ["c1"] });
+    const a = setFlag({ x: -100, y: 200 }, "枝1の中");
+    const b = setFlag({ x: 100, y: 200 }, "デフォルトの中");
+    const join = setFlag({ x: 0, y: 400 }, "合流後");
     const { flowData, warnings } = convert(
-      [cond, left, right],
-      [edge(cond, left, "source-cond-c1"), edge(cond, right, "source-default")],
+      [cond, a, b, join],
+      [
+        edge(cond, a, "source-cond-c1"),
+        edge(cond, b, "source-default"),
+        edge(a, join),
+        edge(b, join),
+      ],
     );
 
+    expect(warnings).toEqual([]);
     const steps = flowData.sections[0].steps;
-    const branch = steps[0];
-    if (branch.type !== "Branch") throw new Error("Branch であるべき");
+    expect(steps.map((s) => s.title)).toEqual(["章で分岐", "合流後"]);
+    const branch = getBranch(steps[0]);
     expect(branch.mode).toBe("auto");
     expect(branch.matchMode).toBe("all");
     expect(branch.executedBranchIds).toEqual(["c1"]);
-    expect(branch.branches).toHaveLength(2);
     expect(branch.branches[0].condition).toBeDefined();
+    expect(branch.branches[0].steps.map((s) => s.title)).toEqual(["枝1の中"]);
     expect(branch.branches[1].condition).toBeUndefined();
-    expect(branch.branches.every((b) => b.steps.length === 0)).toBe(true);
-    expect(steps.map((s) => s.title)).toEqual(["章で分岐", "枝1側", "デフォルト側"]);
-    expect(warnings.some((w) => w.nodeId === cond.id)).toBe(true);
+    expect(branch.branches[1].steps.map((s) => s.title)).toEqual(["デフォルトの中"]);
+  });
+
+  test("合流点へ直接つながる枝は空のまま残る", () => {
+    const cond = conditionalBranch();
+    const a = setFlag({ x: 0, y: 200 }, "枝1の中");
+    const join = setFlag({ x: 0, y: 400 }, "合流後");
+    const { flowData, warnings } = convert(
+      [cond, a, join],
+      [edge(cond, a, "source-cond-c1"), edge(cond, join, "source-default"), edge(a, join)],
+    );
+
+    expect(warnings).toEqual([]);
+    const steps = flowData.sections[0].steps;
+    expect(steps.map((s) => s.title)).toEqual(["章で分岐", "合流後"]);
+    const branch = getBranch(steps[0]);
+    expect(branch.branches[0].steps.map((s) => s.title)).toEqual(["枝1の中"]);
+    expect(branch.branches[1].steps).toEqual([]);
+  });
+
+  test("枝の途中で合流する場合は合流点以降を分岐の後ろへ出す", () => {
+    const cond = conditionalBranch();
+    const a = setFlag({ x: 0, y: 200 }, "枝1の中");
+    const tail = setFlag({ x: 0, y: 400 }, "共有テール");
+    const last = setFlag({ x: 0, y: 600 }, "最後");
+    const { flowData, warnings } = convert(
+      [cond, a, tail, last],
+      [
+        edge(cond, a, "source-cond-c1"),
+        edge(cond, tail, "source-default"),
+        edge(a, tail),
+        edge(tail, last),
+      ],
+    );
+
+    expect(warnings).toEqual([]);
+    const steps = flowData.sections[0].steps;
+    expect(steps.map((s) => s.title)).toEqual(["章で分岐", "共有テール", "最後"]);
+    expect(getBranch(steps[0]).branches[0].steps.map((s) => s.title)).toEqual(["枝1の中"]);
+  });
+
+  test("分岐の中に分岐をネストできる", () => {
+    const outer = conditionalBranch({ title: "外側" });
+    const inner = conditionalBranch({ title: "内側" });
+    inner.position = { x: 0, y: 200 };
+    const a = setFlag({ x: -100, y: 400 }, "内側の枝1");
+    const b = setFlag({ x: 100, y: 400 }, "内側のデフォルト");
+    const join = setFlag({ x: 0, y: 600 }, "合流後");
+    const { flowData, warnings } = convert(
+      [outer, inner, a, b, join],
+      [
+        edge(outer, inner, "source-cond-c1"),
+        edge(outer, join, "source-default"),
+        edge(inner, a, "source-cond-c1"),
+        edge(inner, b, "source-default"),
+        edge(a, join),
+        edge(b, join),
+      ],
+    );
+
+    expect(warnings).toEqual([]);
+    const steps = flowData.sections[0].steps;
+    expect(steps.map((s) => s.title)).toEqual(["外側", "合流後"]);
+    const outerBranch = getBranch(steps[0]);
+    const innerBranch = getBranch(outerBranch.branches[0].steps[0]);
+    expect(innerBranch.title).toBe("内側");
+    expect(innerBranch.branches[0].steps.map((s) => s.title)).toEqual(["内側の枝1"]);
+    expect(innerBranch.branches[1].steps.map((s) => s.title)).toEqual(["内側のデフォルト"]);
+  });
+
+  test("デフォルト枝の実行 (evaluatedConditionIds が空) は default 枝の実行として引き継ぐ", () => {
+    const cond = conditionalBranch({
+      evaluatedConditionIds: [],
+      executedAt: "2026-06-01T00:00:00.000Z",
+    });
+    const { flowData } = convert([cond]);
+
+    const branch = getBranch(flowData.sections[0].steps[0]);
+    expect(branch.executedBranchIds).toEqual(["default"]);
+    expect(branch.executedAt).toEqual(new Date("2026-06-01T00:00:00.000Z"));
+  });
+
+  test("同じ枝ハンドルに複数の接続がある場合はフラット化 + ⚠️ メモ + 警告にフォールバックする", () => {
+    const cond = conditionalBranch();
+    const a = setFlag({ x: 0, y: 200 }, "A");
+    const b = setFlag({ x: 100, y: 200 }, "B");
+    const { flowData, warnings } = convert(
+      [cond, a, b],
+      [edge(cond, a, "source-cond-c1"), edge(cond, b, "source-cond-c1")],
+    );
+
+    const steps = flowData.sections[0].steps;
+    expect(steps.map((s) => s.title)).toEqual(["章で分岐", "A", "B"]);
+    const branch = getBranch(steps[0]);
+    expect(branch.branches.every((arm) => arm.steps.length === 0)).toBe(true);
     expect(branch.memo).toContain("⚠️");
+    expect(warnings.some((w) => w.nodeId === cond.id)).toBe(true);
+  });
+
+  test("対応する枝が無いハンドルの接続はフラット化して警告する", () => {
+    const cond = conditionalBranch();
+    const a = setFlag({ x: 0, y: 200 }, "枝1の中");
+    const zombie = setFlag({ x: 100, y: 200 }, "迷子");
+    const { flowData, warnings } = convert(
+      [cond, a, zombie],
+      [edge(cond, a, "source-cond-c1"), edge(cond, zombie, "source-cond-removed")],
+    );
+
+    const steps = flowData.sections[0].steps;
+    expect(steps.map((s) => s.title)).toEqual(["章で分岐", "迷子"]);
+    expect(getBranch(steps[0]).branches[0].steps.map((s) => s.title)).toEqual(["枝1の中"]);
+    expect(warnings.some((w) => w.nodeId === cond.id)).toBe(true);
+  });
+
+  test("エッジの並び順に関係なく合流点を検出する", () => {
+    const cond = conditionalBranch();
+    const a = setFlag({ x: 0, y: 200 }, "枝1の中");
+    const join = setFlag({ x: 0, y: 400 }, "合流後");
+    const { flowData, warnings } = convert(
+      [cond, a, join],
+      [edge(cond, join, "source-default"), edge(cond, a, "source-cond-c1"), edge(a, join)],
+    );
+
+    expect(warnings).toEqual([]);
+    expect(flowData.sections[0].steps.map((s) => s.title)).toEqual(["章で分岐", "合流後"]);
+    expect(getBranch(flowData.sections[0].steps[0]).branches[0].steps.map((s) => s.title)).toEqual([
+      "枝1の中",
+    ]);
+  });
+
+  test("条件ツリーが壊れている分岐はスキップして警告する", () => {
+    const cond = conditionalBranch({ conditions: [{ id: "c1", root: null }] });
+    const { flowData, warnings } = convert([cond]);
+
+    expect(flowData.sections).toEqual([]);
+    expect(warnings.some((w) => w.nodeId === cond.id)).toBe(true);
+  });
+
+  test("分岐データ自体が壊れている場合はスキップし、接続は辿る", () => {
+    const cond = conditionalBranch({ conditions: "broken" });
+    const next = setFlag({ x: 0, y: 200 }, "次");
+    const { flowData, warnings } = convert([cond, next], [edge(cond, next, "source-cond-c1")]);
+
+    expect(flowData.sections[0].steps.map((s) => s.title)).toEqual(["次"]);
+    expect(warnings.some((w) => w.nodeId === cond.id)).toBe(true);
+  });
+
+  test("分岐以外のノードに複数の接続がある場合は最初のみ辿り、残りは末尾に回す", () => {
+    const s = setFlag({ x: 0, y: 0 }, "S");
+    const a = setFlag({ x: 0, y: 200 }, "A");
+    const b = setFlag({ x: 100, y: 200 }, "B");
+    const { flowData, warnings } = convert([s, a, b], [edge(s, a), edge(s, b)]);
+
+    expect(flowData.sections[0].steps.map((step) => step.title)).toEqual(["S", "A", "B"]);
+    expect(warnings.some((w) => w.nodeId === s.id)).toBe(true);
+  });
+
+  test("Comment はネストされた枝の中のステップにも吸収される", () => {
+    const cond = conditionalBranch();
+    const a = setFlag({ x: 0, y: 200 }, "枝1の中");
+    const c = rfNode(
+      "Comment",
+      { comment: "枝メモ" },
+      { x: 0, y: 220 },
+      { style: { width: 100, height: 50 } },
+    );
+    const { flowData } = convert([cond, a, c], [edge(cond, a, "source-cond-c1")]);
+
+    const branch = getBranch(flowData.sections[0].steps[0]);
+    expect(branch.branches[0].steps[0].memo).toBe("枝メモ");
   });
 });
 

--- a/frontend/src/flow/convert.test.ts
+++ b/frontend/src/flow/convert.test.ts
@@ -103,11 +103,62 @@ describe("convertReactFlowToFlowData: 異常系", () => {
     expect(warnings.some((w) => w.message.includes("循環"))).toBe(true);
   });
 
+  // 合流点計算 (computePostDominators) は逆トポロジカル走査で ipdom を辿るため、
+  // 循環ノードでは ipdom が閉路を成しハングしうる。以下は完了する (ハングしない) ことを検証する
+  test("分岐ノードの一方の枝が循環に入っても変換は完了し、循環を警告する", () => {
+    const br = setFlag({ x: 0, y: 0 }, "Br");
+    const a = setFlag({ x: -100, y: 100 }, "A");
+    const p = setFlag({ x: 100, y: 100 }, "P");
+    const b = setFlag({ x: -100, y: 200 }, "B");
+    const { flowData, warnings } = convert(
+      [br, a, p, b],
+      [edge(br, a), edge(br, p), edge(a, b), edge(b, a)],
+    );
+
+    const titles = flowData.sections.flatMap((s) => s.steps.map((step) => step.title)).sort();
+    expect(titles).toEqual(["A", "B", "Br", "P"]);
+    expect(warnings.some((w) => w.message.includes("循環"))).toBe(true);
+  });
+
+  test("ステップノードの自己ループでも変換は完了し、循環を警告する", () => {
+    const x = setFlag({ x: 0, y: 0 }, "X");
+    const a = setFlag({ x: -100, y: 100 }, "A");
+    const p = setFlag({ x: 100, y: 100 }, "P");
+    const { flowData, warnings } = convert([x, a, p], [edge(x, a), edge(x, p), edge(a, a)]);
+
+    const titles = flowData.sections.flatMap((s) => s.steps.map((step) => step.title)).sort();
+    expect(titles).toEqual(["A", "P", "X"]);
+    expect(warnings.some((w) => w.message.includes("循環"))).toBe(true);
+  });
+
+  test("互いに素な循環へ分岐する場合でも変換は完了し、循環を警告する", () => {
+    const x = setFlag({ x: 0, y: 0 }, "X");
+    const c1 = setFlag({ x: -100, y: 100 }, "C1");
+    const c2 = setFlag({ x: -100, y: 200 }, "C2");
+    const d1 = setFlag({ x: 100, y: 100 }, "D1");
+    const d2 = setFlag({ x: 100, y: 200 }, "D2");
+    const { flowData, warnings } = convert(
+      [x, c1, c2, d1, d2],
+      [edge(x, c1), edge(x, d1), edge(c1, c2), edge(c2, c1), edge(d1, d2), edge(d2, d1)],
+    );
+
+    const titles = flowData.sections.flatMap((s) => s.steps.map((step) => step.title)).sort();
+    expect(titles).toEqual(["C1", "C2", "D1", "D2", "X"]);
+    expect(warnings.some((w) => w.message.includes("循環"))).toBe(true);
+  });
+
   test("読み取れないノードはスキップして警告を返す", () => {
     const { flowData, warnings } = convert([{ id: "broken" }, setFlag({ x: 0, y: 0 }, "A")]);
 
     expect(flowData.sections[0].steps.map((s) => s.title)).toEqual(["A"]);
     expect(warnings).toHaveLength(1);
+  });
+
+  test("読み取れないエッジはスキップして警告を返す", () => {
+    const a = setFlag({ x: 0, y: 0 }, "A");
+    const { warnings } = convert([a], [{ id: "broken-edge" }]);
+
+    expect(warnings.some((w) => w.message.includes("接続を読み取れなかった"))).toBe(true);
   });
 
   test("新スキーマの検証に失敗するノードはスキップして警告を返す", () => {

--- a/frontend/src/flow/convert.ts
+++ b/frontend/src/flow/convert.ts
@@ -249,25 +249,25 @@ function computePostDominators(
   outgoing: Map<string, RFEdge[]>,
 ): Map<string, JoinPoint> {
   const ipdom = new Map<string, JoinPoint>();
-  const depth = new Map<JoinPoint, number>([[EXIT, 0]]);
-  const depthOf = (node: JoinPoint) => depth.get(node) ?? 0;
   const climb = (node: JoinPoint): JoinPoint => (node === EXIT ? EXIT : (ipdom.get(node) ?? EXIT));
+  // ipdom チェーン上の最近共通祖先 (LCA)。循環ノード (末尾に足された循環部) では
+  // ipdom が閉路を成しうるため、閉路を検知したら合流点なしの EXIT へ縮退する
   const intersect = (aIn: JoinPoint, bIn: JoinPoint): JoinPoint => {
-    let a = aIn;
-    let b = bIn;
-    while (a !== b) {
-      const da = depthOf(a);
-      const db = depthOf(b);
-      if (da > db) {
-        a = climb(a);
-      } else if (db > da) {
-        b = climb(b);
-      } else {
-        a = climb(a);
-        b = climb(b);
-      }
+    const ancestors = new Set<JoinPoint>();
+    let a: JoinPoint = aIn;
+    while (!ancestors.has(a)) {
+      ancestors.add(a);
+      if (a === EXIT) break;
+      a = climb(a);
     }
-    return a;
+    let b: JoinPoint = bIn;
+    const seen = new Set<JoinPoint>();
+    while (!ancestors.has(b)) {
+      if (b === EXIT || seen.has(b)) return EXIT;
+      seen.add(b);
+      b = climb(b);
+    }
+    return b;
   };
 
   for (const node of [...order].reverse()) {
@@ -280,7 +280,6 @@ function computePostDominators(
       }
     }
     ipdom.set(node.id, join);
-    depth.set(node.id, depthOf(join) + 1);
   }
   return ipdom;
 }
@@ -469,7 +468,11 @@ export function convertReactFlowToFlowData(input: unknown): {
   const edges: RFEdge[] = [];
   for (const rawEdge of parsed.edges) {
     const result = RFEdgeSchema.safeParse(rawEdge);
-    if (result.success) edges.push(result.data);
+    if (result.success) {
+      edges.push(result.data);
+    } else {
+      warnings.push({ message: "接続を読み取れなかったためスキップしました" });
+    }
   }
 
   const groups = nodes.filter((node) => node.type === "LabeledGroup");

--- a/frontend/src/flow/convert.ts
+++ b/frontend/src/flow/convert.ts
@@ -9,7 +9,8 @@ import type { FlowData, Step } from "./schema";
 import { FlowDataSchema, StepSchema } from "./schema";
 
 // reactFlowData (グラフ) → FlowData (ステップツリー) のベストエフォート変換器。
-// 変換しきれない構造は捨てずにフラット化し、⚠️ メモと警告で手直しを促す。
+// 分岐は最近共通合流点 (immediate post-dominator) を検出して branches[].steps にネストし、
+// 変換しきれない構造は捨てずにフラット化 + ⚠️ メモと警告で手直しを促す。
 
 type ConversionWarning = {
   message: string;
@@ -70,6 +71,11 @@ const STEP_NODE_TYPES = new Set([
 
 const UNGROUPED = Symbol("ungrouped");
 const UNGROUPED_TITLE = "未分類";
+const DEFAULT_ARM_ID = "default";
+
+// 仮想終端。合流点が無い (全枝が末端まで流れる) ことを表す
+const EXIT = Symbol("exit");
+type JoinPoint = string | typeof EXIT;
 
 const sizeOf = (node: RFNode) => ({
   width: node.measured?.width ?? node.width ?? node.style?.width ?? 0,
@@ -113,47 +119,6 @@ function findContainingGroup(node: RFNode, groups: RFNode[]): RFNode | undefined
   return innermost;
 }
 
-// エッジを尊重したトポロジカル順 (Kahn 法)。同時に実行可能なノードは座標 (y, x) 順。
-// 循環で残ったノードは座標順で末尾に足し、警告を返す。
-function orderStepNodes(
-  stepNodes: RFNode[],
-  edges: RFEdge[],
-  warnings: ConversionWarning[],
-): RFNode[] {
-  const byId = new Map(stepNodes.map((node) => [node.id, node]));
-  const outgoing = new Map<string, string[]>();
-  const inDegree = new Map<string, number>(stepNodes.map((node) => [node.id, 0]));
-  for (const edge of edges) {
-    if (!byId.has(edge.source) || !byId.has(edge.target)) continue;
-    outgoing.set(edge.source, [...(outgoing.get(edge.source) ?? []), edge.target]);
-    inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
-  }
-
-  const ready = stepNodes.filter((node) => inDegree.get(node.id) === 0).sort(byPosition);
-  const ordered: RFNode[] = [];
-  while (ready.length > 0) {
-    const node = ready.shift() as RFNode;
-    ordered.push(node);
-    const becameReady: RFNode[] = [];
-    for (const targetId of outgoing.get(node.id) ?? []) {
-      const remaining = (inDegree.get(targetId) ?? 0) - 1;
-      inDegree.set(targetId, remaining);
-      if (remaining === 0) becameReady.push(byId.get(targetId) as RFNode);
-    }
-    // 直後に実行可能になったノードを優先しつつ、複数あれば座標順で先頭に挿入する
-    ready.unshift(...becameReady.sort(byPosition));
-  }
-
-  if (ordered.length < stepNodes.length) {
-    const leftover = stepNodes.filter((node) => !ordered.includes(node)).sort(byPosition);
-    warnings.push({
-      message: `循環した接続があるため ${leftover.length} 個のノードを末尾に配置しました`,
-    });
-    ordered.push(...leftover);
-  }
-  return ordered;
-}
-
 function titleOf(node: RFNode): string {
   const title = node.data.title;
   return typeof title === "string" && title !== "" ? title : node.type;
@@ -180,11 +145,34 @@ function armLabel(root: unknown, index: number): string {
   }
 }
 
+type BranchArmCandidate = {
+  id: string;
+  label: string;
+  condition?: unknown;
+  steps: unknown[];
+};
+
 // ノード → ステップ候補 (parse 前の生データ)。分岐 2 種は統合 Branch 型へ再構成し、
 // それ以外は data のフィールド名が新スキーマと同じためそのまま引き継ぐ。
 function toStepCandidate(node: RFNode): Record<string, unknown> {
   if (node.type === "ConditionalBranch") {
     const data = ConditionalBranchDataSchema.parse(node.data);
+    const branches: BranchArmCandidate[] = [
+      ...data.conditions.map((condition, index) => ({
+        id: condition.id,
+        label: armLabel(condition.root, index),
+        condition: condition.root,
+        steps: [],
+      })),
+      ...(data.hasDefaultBranch ? [{ id: DEFAULT_ARM_ID, label: "デフォルト", steps: [] }] : []),
+    ];
+    // 旧実装は「どの条件にもマッチせずデフォルト枝が実行された」とき空配列を記録する
+    const executedBranchIds =
+      data.evaluatedConditionIds === undefined
+        ? undefined
+        : data.evaluatedConditionIds.length === 0 && data.hasDefaultBranch
+          ? [DEFAULT_ARM_ID]
+          : data.evaluatedConditionIds;
     return {
       id: node.id,
       type: "Branch",
@@ -192,16 +180,8 @@ function toStepCandidate(node: RFNode): Record<string, unknown> {
       executedAt: node.data.executedAt,
       mode: "auto",
       matchMode: data.matchMode,
-      branches: [
-        ...data.conditions.map((condition, index) => ({
-          id: condition.id,
-          label: armLabel(condition.root, index),
-          condition: condition.root,
-          steps: [],
-        })),
-        ...(data.hasDefaultBranch ? [{ id: "default", label: "デフォルト", steps: [] }] : []),
-      ],
-      executedBranchIds: data.evaluatedConditionIds,
+      branches,
+      executedBranchIds,
     };
   }
   if (node.type === "SelectBranch") {
@@ -219,6 +199,255 @@ function toStepCandidate(node: RFNode): Record<string, unknown> {
     };
   }
   return { ...node.data, id: node.id, type: node.type, title: titleOf(node) };
+}
+
+type CandidateEntry = { node: RFNode; candidate: Record<string, unknown> };
+
+// エッジ順 (Kahn 法) のトポロジカル順。循環で並べきれないノードは警告して座標順で末尾に足す
+function topologicalOrder(
+  stepNodes: RFNode[],
+  edges: RFEdge[],
+  warnings: ConversionWarning[],
+): RFNode[] {
+  const byId = new Map(stepNodes.map((node) => [node.id, node]));
+  const outgoing = new Map<string, string[]>();
+  const inDegree = new Map<string, number>(stepNodes.map((node) => [node.id, 0]));
+  for (const edge of edges) {
+    if (!byId.has(edge.source) || !byId.has(edge.target)) continue;
+    outgoing.set(edge.source, [...(outgoing.get(edge.source) ?? []), edge.target]);
+    inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
+  }
+
+  const ready = stepNodes.filter((node) => inDegree.get(node.id) === 0).sort(byPosition);
+  const ordered: RFNode[] = [];
+  while (ready.length > 0) {
+    const node = ready.shift() as RFNode;
+    ordered.push(node);
+    const becameReady: RFNode[] = [];
+    for (const targetId of outgoing.get(node.id) ?? []) {
+      const remaining = (inDegree.get(targetId) ?? 0) - 1;
+      inDegree.set(targetId, remaining);
+      if (remaining === 0) becameReady.push(byId.get(targetId) as RFNode);
+    }
+    ready.unshift(...becameReady.sort(byPosition));
+  }
+
+  if (ordered.length < stepNodes.length) {
+    const leftover = stepNodes.filter((node) => !ordered.includes(node)).sort(byPosition);
+    warnings.push({
+      message: `循環した接続があるため ${leftover.length} 個のノードを末尾に配置しました`,
+    });
+    ordered.push(...leftover);
+  }
+  return ordered;
+}
+
+// 各ノードの最近共通合流点 (immediate post-dominator)。
+// 後続が無いノードは EXIT。前提: order は (循環部を末尾に足した) トポロジカル順
+function computePostDominators(
+  order: RFNode[],
+  outgoing: Map<string, RFEdge[]>,
+): Map<string, JoinPoint> {
+  const ipdom = new Map<string, JoinPoint>();
+  const depth = new Map<JoinPoint, number>([[EXIT, 0]]);
+  const depthOf = (node: JoinPoint) => depth.get(node) ?? 0;
+  const climb = (node: JoinPoint): JoinPoint => (node === EXIT ? EXIT : (ipdom.get(node) ?? EXIT));
+  const intersect = (aIn: JoinPoint, bIn: JoinPoint): JoinPoint => {
+    let a = aIn;
+    let b = bIn;
+    while (a !== b) {
+      const da = depthOf(a);
+      const db = depthOf(b);
+      if (da > db) {
+        a = climb(a);
+      } else if (db > da) {
+        b = climb(b);
+      } else {
+        a = climb(a);
+        b = climb(b);
+      }
+    }
+    return a;
+  };
+
+  for (const node of [...order].reverse()) {
+    const successors = [...new Set((outgoing.get(node.id) ?? []).map((edge) => edge.target))];
+    let join: JoinPoint = EXIT;
+    if (successors.length > 0) {
+      join = successors[0];
+      for (const successor of successors.slice(1)) {
+        join = intersect(join, successor);
+      }
+    }
+    ipdom.set(node.id, join);
+    depth.set(node.id, depthOf(join) + 1);
+  }
+  return ipdom;
+}
+
+// グラフを再帰的に歩き、分岐は合流点までを branches[].steps にネストした候補ツリーを作る。
+// topLevel はセクション割り当て対象、all はメモ吸収 (Comment) の対象
+function buildStructure(
+  stepNodes: RFNode[],
+  edges: RFEdge[],
+  warnings: ConversionWarning[],
+): { topLevel: CandidateEntry[]; all: CandidateEntry[] } {
+  const byId = new Map(stepNodes.map((node) => [node.id, node]));
+  const stepEdges = edges.filter((edge) => byId.has(edge.source) && byId.has(edge.target));
+  const outgoing = new Map<string, RFEdge[]>();
+  const hasIncoming = new Set<string>();
+  for (const edge of stepEdges) {
+    outgoing.set(edge.source, [...(outgoing.get(edge.source) ?? []), edge]);
+    hasIncoming.add(edge.target);
+  }
+
+  const order = topologicalOrder(stepNodes, stepEdges, warnings);
+  const ipdom = computePostDominators(order, outgoing);
+
+  const topLevel: CandidateEntry[] = [];
+  const all: CandidateEntry[] = [];
+  const consumed = new Set<string>();
+
+  const makeEntry = (node: RFNode): CandidateEntry | null => {
+    try {
+      const candidate = toStepCandidate(node);
+      // 分岐は枝を埋めた後 (セクション組み立て時) に検証する
+      if (node.type !== "ConditionalBranch" && !StepSchema.safeParse(candidate).success) {
+        warnings.push({
+          nodeId: node.id,
+          message: `ノード「${titleOf(node)}」のデータが不正なためスキップしました`,
+        });
+        return null;
+      }
+      return { node, candidate };
+    } catch {
+      warnings.push({
+        nodeId: node.id,
+        message: `ノード「${titleOf(node)}」のデータを変換できなかったためスキップしました`,
+      });
+      return null;
+    }
+  };
+
+  const walkChain = (
+    startId: string | null,
+    stops: ReadonlySet<string>,
+    sink: CandidateEntry[],
+  ) => {
+    let cur = startId;
+    while (cur !== null && !stops.has(cur)) {
+      if (consumed.has(cur)) {
+        warnings.push({
+          nodeId: cur,
+          message: "複雑な接続のため、一部の接続を辿りませんでした",
+        });
+        break;
+      }
+      const nodeId = cur;
+      const node = byId.get(nodeId);
+      if (!node) break;
+      consumed.add(nodeId);
+
+      const entry = makeEntry(node);
+      if (entry && node.type === "ConditionalBranch") {
+        sink.push(entry);
+        all.push(entry);
+        const join = buildBranch(entry, sink, stops);
+        cur = join === EXIT ? null : join;
+        continue;
+      }
+      if (entry) {
+        sink.push(entry);
+        all.push(entry);
+      }
+      const targets = (outgoing.get(nodeId) ?? []).map((edge) => edge.target);
+      if (targets.length > 1) {
+        warnings.push({
+          nodeId,
+          message: `「${titleOf(node)}」に複数の接続があるため、最初の接続のみを辿りました`,
+        });
+      }
+      cur = targets[0] ?? null;
+    }
+  };
+
+  // 分岐の各枝を合流点までネストする。ハンドルが解釈できない構造は
+  // フラット化 (親チェーンへ展開) + ⚠️ メモにフォールバックする
+  const buildBranch = (
+    entry: CandidateEntry,
+    sink: CandidateEntry[],
+    stops: ReadonlySet<string>,
+  ): JoinPoint => {
+    const node = entry.node;
+    const branchEdges = outgoing.get(node.id) ?? [];
+    const arms = entry.candidate.branches as BranchArmCandidate[];
+
+    const edgesOf = (arm: BranchArmCandidate) => {
+      const handle = arm.id === DEFAULT_ARM_ID ? "source-default" : `source-cond-${arm.id}`;
+      return branchEdges.filter((edge) => edge.sourceHandle === handle);
+    };
+
+    // 未結線の枝は「そこで流れが終わる」ため、合流点は存在しない (EXIT) とみなす。
+    // そうしないと唯一の後続が合流点扱いになり、枝の中身が分岐の外へ巻き上がってしまう
+    const hasUnwiredArm = arms.some((arm) => edgesOf(arm).length === 0);
+    const join: JoinPoint = hasUnwiredArm ? EXIT : (ipdom.get(node.id) ?? EXIT);
+    const armStops = join === EXIT ? stops : new Set([...stops, join]);
+
+    if (arms.some((arm) => edgesOf(arm).length > 1)) {
+      entry.candidate.memo = appendMemo(
+        (entry.candidate.memo as string | undefined) ?? "",
+        "⚠️ 分岐の枝を自動ネスト化できなかったため、後続ステップをフラットに並べています。枝の内容を手動で移動してください。",
+      );
+      warnings.push({
+        nodeId: node.id,
+        message: `分岐「${titleOf(node)}」の後続をフラット化しました`,
+      });
+      for (const edge of branchEdges) {
+        walkChain(edge.target, armStops, sink);
+      }
+      return join;
+    }
+
+    const knownEdges = new Set(arms.flatMap((arm) => edgesOf(arm)));
+    for (const arm of arms) {
+      const target = edgesOf(arm)[0]?.target ?? null;
+      if (target === null || target === join) continue;
+      const armSink: CandidateEntry[] = [];
+      walkChain(target, armStops, armSink);
+      arm.steps = armSink.map((armEntry) => armEntry.candidate);
+    }
+
+    const leftovers = branchEdges.filter((edge) => !knownEdges.has(edge));
+    if (leftovers.length > 0) {
+      warnings.push({
+        nodeId: node.id,
+        message: `分岐「${titleOf(node)}」に対応する枝が見つからない接続があるため、フラットに並べました`,
+      });
+      for (const edge of leftovers) {
+        walkChain(edge.target, armStops, sink);
+      }
+    }
+    return join;
+  };
+
+  const noStops: ReadonlySet<string> = new Set();
+  const roots = stepNodes.filter((node) => !hasIncoming.has(node.id)).sort(byPosition);
+  for (const root of roots) {
+    walkChain(root.id, noStops, topLevel);
+  }
+
+  // 異常な構造 (循環・辿れなかった接続) で残ったノードの受け皿。データは捨てない
+  let warnedLeftover = false;
+  while (consumed.size < stepNodes.length) {
+    const remaining = stepNodes.filter((node) => !consumed.has(node.id)).sort(byPosition);
+    if (!warnedLeftover) {
+      warnings.push({ message: "接続を辿れなかったステップを末尾に配置しました" });
+      warnedLeftover = true;
+    }
+    walkChain(remaining[0].id, noStops, topLevel);
+  }
+
+  return { topLevel, all };
 }
 
 export function convertReactFlowToFlowData(input: unknown): {
@@ -258,39 +487,8 @@ export function convertReactFlowToFlowData(input: unknown): {
     }
   }
 
-  const ordered = orderStepNodes(stepNodes, edges, warnings);
+  const { topLevel, all } = buildStructure(stepNodes, edges, warnings);
   const groupKeyOf = (node: RFNode) => findContainingGroup(node, groups)?.id ?? UNGROUPED;
-
-  // ステップ候補を組み立て、検証に失敗したものは捨てて警告にする
-  const candidates: { node: RFNode; candidate: Record<string, unknown> }[] = [];
-  for (const node of ordered) {
-    try {
-      candidates.push({ node, candidate: toStepCandidate(node) });
-    } catch {
-      warnings.push({
-        nodeId: node.id,
-        message: `ノード「${titleOf(node)}」のデータを変換できなかったためスキップしました`,
-      });
-    }
-  }
-
-  // ConditionalBranch の後続はネスト化せずフラットに並ぶ (合流点検出は後続 PR)
-  const outgoingCount = new Map<string, number>();
-  for (const edge of edges) {
-    outgoingCount.set(edge.source, (outgoingCount.get(edge.source) ?? 0) + 1);
-  }
-  for (const { node, candidate } of candidates) {
-    if (node.type === "ConditionalBranch" && (outgoingCount.get(node.id) ?? 0) > 0) {
-      candidate.memo = appendMemo(
-        (candidate.memo as string | undefined) ?? "",
-        "⚠️ 分岐の枝を自動ネスト化できなかったため、後続ステップをフラットに並べています。枝の内容を手動で移動してください。",
-      );
-      warnings.push({
-        nodeId: node.id,
-        message: `分岐「${titleOf(node)}」の後続をフラット化しました`,
-      });
-    }
-  }
 
   // Comment の吸収: グループ内なら同グループ内の最近接ステップ、いなければセクション memo へ。
   // グループ外なら全ステップ中の最近接へ
@@ -303,9 +501,7 @@ export function convertReactFlowToFlowData(input: unknown): {
     if (text === "") continue;
     const groupKey = groupKeyOf(comment);
     const scope =
-      groupKey === UNGROUPED
-        ? candidates
-        : candidates.filter(({ node }) => groupKeyOf(node) === groupKey);
+      groupKey === UNGROUPED ? all : all.filter(({ node }) => groupKeyOf(node) === groupKey);
     const nearest = [...scope].sort(
       (a, b) => distance(a.node, comment) - distance(b.node, comment),
     )[0];
@@ -340,7 +536,7 @@ export function convertReactFlowToFlowData(input: unknown): {
   const sections: { id: string; title: string; memo: string; steps: Step[] }[] = [];
   const runCount = new Map<string | typeof UNGROUPED, number>();
   let currentKey: string | typeof UNGROUPED | null = null;
-  for (const { node, candidate } of candidates) {
+  for (const { node, candidate } of topLevel) {
     const stepResult = StepSchema.safeParse(candidate);
     if (!stepResult.success) {
       warnings.push({


### PR DESCRIPTION
#183 (= #182 Phase 0) の Stacked PRs **3/3**(base: #185)。ConditionalBranch の枝の中身を `branches[].steps` にネストし、合流点以降を分岐ステップの後ろへ直列で続けます。これで Phase 0 のスコープが完了します。

## 内容
- **合流点検出**(インタビュー決定: 共通合流点を検出): 各ノードの immediate post-dominator を計算し、分岐の合流点とする。エッジの並び順に依存しない
- **未結線の枝**がある分岐は合流点なし(EXIT)とみなす — そうしないと唯一の後続が合流点扱いになり枝の中身が分岐の外へ巻き上がるため
- **停止点スタック**: ネストした分岐の枝歩きが外側の合流点を越えないようにする(分岐 in 分岐対応)
- **実行状態の忠実な引き継ぎ**: 旧実装は「デフォルト枝が実行された」とき `evaluatedConditionIds: []` を記録するため、`executedBranchIds: ["default"]` に変換
- **フォールバック**(ベストエフォート): 同一ハンドルへの複数接続 / 対応する枝が無い接続 / 複雑な合流は、フラット化 + ⚠️ メモ + 警告でデータを捨てずに手直し可能にする
- 異常構造(循環・辿れない接続)の受け皿として未消費ノードを末尾配置

## チェック
- `frontend/src/flow/` 37 tests pass、`convert.ts` / `schema.ts` カバレッジ 100%
- `bun run --bun test` / `typecheck` / `format` / `lint` / `bun run knip` ✅

マージ順: #184 → #185 → 本PR(マージで #183 クローズ可)

Closes #183

https://claude.ai/code/session_01MXZ1fFpAyiz7eHZvJ7tweX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXZ1fFpAyiz7eHZvJ7tweX)_