### PR TITLE
Update Claude settings: refactor env setup and remove unused plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ \"$CLAUDE_CODE_REMOTE\" = \"true\" ]; then ( cd \"$CLAUDE_PROJECT_DIR\" && devbox shellenv --init-hook=false ) > \"$CLAUDE_ENV_FILE\"; else direnv export bash > \"$CLAUDE_ENV_FILE\"; fi"
+            "command": "if [ \"$CLAUDE_CODE_REMOTE\" = \"true\" ]; then bash \"$CLAUDE_PROJECT_DIR/.claude/scripts/setup-ccweb.sh\"; else direnv export bash > \"$CLAUDE_ENV_FILE\"; fi"
           }
         ]
       }
@@ -46,15 +46,6 @@
   },
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
-    "context-mode@context-mode": true,
     "frontend-design@claude-plugins-official": true
-  },
-  "extraKnownMarketplaces": {
-    "context-mode": {
-      "source": {
-        "source": "github",
-        "repo": "mksglu/context-mode"
-      }
-    }
   }
 }


### PR DESCRIPTION
## Summary
Updates `.claude/settings.json` to improve environment setup handling and clean up unused plugin configurations.

## Key Changes
- **Environment setup refactoring**: Changed the remote environment initialization from inline `devbox shellenv` command to a dedicated bash script (`setup-ccweb.sh`), improving maintainability and allowing for more complex setup logic
- **Plugin cleanup**: Removed the unused `context-mode` plugin and its associated marketplace configuration from enabled plugins

## Implementation Details
- The environment hook now delegates to `.claude/scripts/setup-ccweb.sh` when running in remote mode (`CLAUDE_CODE_REMOTE=true`), while preserving the existing `direnv export bash` fallback for local development
- Removed `context-mode@context-mode` plugin entry and the entire `extraKnownMarketplaces` section that was only used to configure that plugin
- Retained the active plugins: `context7@claude-plugins-official` and `frontend-design@claude-plugins-official`

https://claude.ai/code/session_01MXZ1fFpAyiz7eHZvJ7tweX