### PR TITLE
feat(db): flowData マイグレーション (issue #182 Phase 1)

### DIFF
--- a/docs/dev/step-list-editor-architecture.md
+++ b/docs/dev/step-list-editor-architecture.md
@@ -239,9 +239,16 @@ The new editor ships on **separate routes** and runs alongside React Flow until 
   existing `getParsedReactFlowData` / `update` pattern).
 - Bulk-convert existing records via the next Dexie version (`this.version(7).upgrade`) using
   `convertReactFlowToFlowData`. **Keep `reactFlowData`** (old UI + backup); do not delete it.
-- Surface converter `warnings` so the user can fix flattened structures. Decide where warnings
-  live (e.g. an injected `⚠️` memo on the affected step/section) during Phase 1 design.
+- Surface converter `warnings` so the user can fix flattened structures. **Resolved (Phase 1):**
+  `foldWarningsIntoFlowData` in `flow/migrate.ts` folds them into `⚠️` memos — a `nodeId`-matched
+  warning is appended to that step's `memo` (recursing into `branches[].steps`); the rest (global
+  warnings / unrealized groups) are aggregated into the first section's `memo`, or a synthetic
+  `conversion-warnings` section if the flow has none. Nothing is dropped.
 - **Use the `schema-migration` skill** for the Dexie work. Migrate both tables with `modify()`.
+  **Implemented:** the per-record transform (`migrateRecordToFlowData`) and the both-tables
+  `modify()` routine (`applyFlowDataMigration`) live in `flow/migrate.ts` (pure, unit-tested);
+  `database.ts`'s `version(7).upgrade` is a thin caller. `migrateRecordToFlowData` is idempotent:
+  a record that already holds valid `flowData` is kept as-is, so re-running is safe.
 
 ---
 

--- a/docs/dev/step-list-editor-architecture.md
+++ b/docs/dev/step-list-editor-architecture.md
@@ -240,15 +240,21 @@ The new editor ships on **separate routes** and runs alongside React Flow until 
 - Bulk-convert existing records via the next Dexie version (`this.version(7).upgrade`) using
   `convertReactFlowToFlowData`. **Keep `reactFlowData`** (old UI + backup); do not delete it.
 - Surface converter `warnings` so the user can fix flattened structures. **Resolved (Phase 1):**
-  `foldWarningsIntoFlowData` in `flow/migrate.ts` folds them into `⚠️` memos — a `nodeId`-matched
-  warning is appended to that step's `memo` (recursing into `branches[].steps`); the rest (global
-  warnings / unrealized groups) are aggregated into the first section's `memo`, or a synthetic
-  `conversion-warnings` section if the flow has none. Nothing is dropped.
+  `foldWarningsIntoFlowData` in `flow/migrate.ts` folds them into `⚠️` memos — a `nodeId` matching a
+  step appends to that step's `memo` (recursing into `branches[].steps`), one matching a section
+  appends to that section's `memo`; every remaining warning (no `nodeId`, or a `nodeId` that is
+  neither a step nor a section — global warnings, unrealized groups, etc.) is aggregated into the
+  first section's `memo`, or a synthetic `conversion-warnings` section if the flow has none.
+  Nothing is dropped.
 - **Use the `schema-migration` skill** for the Dexie work. Migrate both tables with `modify()`.
-  **Implemented:** the per-record transform (`migrateRecordToFlowData`) and the both-tables
-  `modify()` routine (`applyFlowDataMigration`) live in `flow/migrate.ts` (pure, unit-tested);
-  `database.ts`'s `version(7).upgrade` is a thin caller. `migrateRecordToFlowData` is idempotent:
-  a record that already holds valid `flowData` is kept as-is, so re-running is safe.
+  **Implemented:** the pure, unit-tested transforms (`migrateRecordToFlowData` /
+  `reactFlowToFlowData` / `foldWarningsIntoFlowData`) and the side-effecting orchestrator that
+  `modify()`s both tables (`applyFlowDataMigration`, fake-indexeddb integration-tested) live in
+  `flow/migrate.ts`; `database.ts`'s `version(7).upgrade` is a thin caller. `migrateRecordToFlowData`
+  is idempotent: a record that already holds valid `flowData` is kept as-is, so re-running is safe.
+- A record's `flowData` file paths are kept identical to its `reactFlowData` paths. Session
+  creation (`CreateSession`) and template import (`importTemplate`) rewrite both with the same
+  replacer (`convertFilePathsInFlowData` mirrors `convertFilePathsInReactFlowData`).
 
 ---
 

--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -3,10 +3,13 @@ import type z from "zod";
 import { useLiveQuery } from "dexie-react-hooks";
 import { type MouseEvent, useEffect, useState } from "react";
 
+import type { FlowData } from "@/flow/schema";
+
 import { ApiClient } from "@/api";
 import { db, type ReactFlowData } from "@/db";
 import { type GuildSchema } from "@/db";
 import { FileSystem, convertFilePathsInReactFlowData } from "@/fileSystem";
+import { convertFilePathsInFlowData } from "@/flow/filePaths";
 import { useToast } from "@/toast/ToastProvider";
 
 interface Props {
@@ -81,8 +84,8 @@ export const CreateSession = ({ onCreate, onCancel }: Props) => {
         guildId: selectedGuildId,
         botId: selectedBotId,
         gameFlags: template.gameFlags,
+        // reactFlowData / flowData ともパスは下の update で session/{id}/ へ書き換える
         reactFlowData: template.reactFlowData,
-        // flowData 内のファイルパス書き換えは新ランナー (Phase 3) で対応するため、ここでは複製のみ
         flowData: template.flowData,
         createdAt: new Date(),
         lastUsedAt: new Date(),
@@ -92,13 +95,20 @@ export const CreateSession = ({ onCreate, onCancel }: Props) => {
       const fileSystem = new FileSystem();
       await fileSystem.copyTemplateFilesToSession(selectedTemplateId, newSessionId);
 
+      // reactFlowData と flowData はファイルパスを共有するため、同じ replacer で両方書き換える
+      const replaceFilePath = (filePath: string) =>
+        filePath.replace(`template/${selectedTemplateId}/`, `session/${newSessionId}/`);
       const parsed: ReactFlowData = JSON.parse(template.reactFlowData);
-      const converted = convertFilePathsInReactFlowData(parsed, (filePath) =>
-        filePath.replace(`template/${selectedTemplateId}/`, `session/${newSessionId}/`),
+      const convertedReactFlowData = JSON.stringify(
+        convertFilePathsInReactFlowData(parsed, replaceFilePath),
       );
-      const convertedReactFlowData = JSON.stringify(converted);
+      const parsedFlow: FlowData = JSON.parse(template.flowData);
+      const convertedFlowData = JSON.stringify(
+        convertFilePathsInFlowData(parsedFlow, replaceFilePath),
+      );
       await db.GameSession.update(newSessionId, {
         reactFlowData: convertedReactFlowData,
+        flowData: convertedFlowData,
       });
 
       addToast({

--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -82,6 +82,8 @@ export const CreateSession = ({ onCreate, onCancel }: Props) => {
         botId: selectedBotId,
         gameFlags: template.gameFlags,
         reactFlowData: template.reactFlowData,
+        // flowData 内のファイルパス書き換えは新ランナー (Phase 3) で対応するため、ここでは複製のみ
+        flowData: template.flowData,
         createdAt: new Date(),
         lastUsedAt: new Date(),
       });

--- a/frontend/src/db/database.ts
+++ b/frontend/src/db/database.ts
@@ -18,6 +18,8 @@ import type {
   TemplateData,
 } from "./schemas";
 
+import { applyFlowDataMigration } from "../flow/migrate";
+
 const ReactFlowNodeSchema = z.looseObject({
   type: z.string().optional(),
   data: z.record(z.string(), z.unknown()).optional(),
@@ -310,5 +312,16 @@ export class DB extends Dexie {
           session.reactFlowData = migrateReactFlowData(session.reactFlowData);
         });
     });
+
+    // issue #182 Phase 1: ステップリスト型エディタ用の flowData を追加。既存の
+    // reactFlowData を best-effort 変換して両テーブルへ付与する。reactFlowData は
+    // 旧 UI + バックアップとして保持する (削除しない)。
+    this.version(7)
+      .stores({
+        GameSession:
+          "++id, name, guildId, botId, gameFlags, reactFlowData, flowData, createdAt, lastUsedAt",
+        Template: "++id, name, gameFlags, reactFlowData, flowData, createdAt, updatedAt",
+      })
+      .upgrade(applyFlowDataMigration);
   }
 }

--- a/frontend/src/db/flowDataMigration.test.ts
+++ b/frontend/src/db/flowDataMigration.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import Dexie from "dexie";
+
+import { applyFlowDataMigration } from "@/flow/migrate";
+import { FlowDataSchema } from "@/flow/schema";
+
+// version(7) の flowData マイグレーションを実 IndexedDB (fake-indexeddb) 上で検証する。
+// 純粋ロジックは migrate.test.ts が網羅するので、ここは「v6 → v7 の upgrade が両テーブルへ
+// 適用され、legacy は変換・already-new は保持・reactFlowData は維持される」ことを確認する。
+// fake-indexeddb の配線は test/unit.setup.ts の db import で済んでいる前提。
+
+const DB_NAME = "FlowDataMigrationTest";
+
+const V6_STORES = {
+  Template: "++id, name, gameFlags, reactFlowData, createdAt, updatedAt",
+  GameSession: "++id, name, guildId, botId, gameFlags, reactFlowData, createdAt, lastUsedAt",
+};
+
+const V7_STORES = {
+  Template: "++id, name, gameFlags, reactFlowData, flowData, createdAt, updatedAt",
+  GameSession:
+    "++id, name, guildId, botId, gameFlags, reactFlowData, flowData, createdAt, lastUsedAt",
+};
+
+const legacyReactFlow = JSON.stringify({
+  nodes: [
+    {
+      id: "n1",
+      type: "SetGameFlag",
+      position: { x: 0, y: 0 },
+      data: { title: "開始", flagKey: "k", flagValue: "v" },
+    },
+  ],
+  edges: [],
+  viewport: { x: 0, y: 0, zoom: 1 },
+});
+
+const existingFlow = JSON.stringify({
+  version: 1,
+  sections: [{ id: "kept", title: "既存", memo: "", collapsed: false, steps: [] }],
+});
+
+afterEach(async () => {
+  await Dexie.delete(DB_NAME);
+});
+
+describe("flowData migration (v6 → v7)", () => {
+  test("両テーブルの legacy を変換し、already-new を保持し、reactFlowData を維持する", async () => {
+    // --- v6 でレコードを投入 ---
+    const oldDb = new Dexie(DB_NAME);
+    oldDb.version(6).stores(V6_STORES);
+    await oldDb.open();
+
+    const now = new Date();
+    const tplLegacyId = await oldDb.table("Template").add({
+      name: "t-legacy",
+      gameFlags: "{}",
+      reactFlowData: legacyReactFlow,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const tplNewId = await oldDb.table("Template").add({
+      name: "t-new",
+      gameFlags: "{}",
+      reactFlowData: legacyReactFlow,
+      flowData: existingFlow,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const sesLegacyId = await oldDb.table("GameSession").add({
+      name: "s-legacy",
+      guildId: "g",
+      botId: "b",
+      gameFlags: "{}",
+      reactFlowData: legacyReactFlow,
+      createdAt: now,
+      lastUsedAt: now,
+    });
+    const sesNewId = await oldDb.table("GameSession").add({
+      name: "s-new",
+      guildId: "g",
+      botId: "b",
+      gameFlags: "{}",
+      reactFlowData: legacyReactFlow,
+      flowData: existingFlow,
+      createdAt: now,
+      lastUsedAt: now,
+    });
+    oldDb.close();
+
+    // --- v7 で開く → upgrade が走る ---
+    const newDb = new Dexie(DB_NAME);
+    newDb.version(6).stores(V6_STORES);
+    newDb.version(7).stores(V7_STORES).upgrade(applyFlowDataMigration);
+    await newDb.open();
+
+    const tplLegacy = await newDb.table("Template").get(tplLegacyId);
+    const tplNew = await newDb.table("Template").get(tplNewId);
+    const sesLegacy = await newDb.table("GameSession").get(sesLegacyId);
+    const sesNew = await newDb.table("GameSession").get(sesNewId);
+    newDb.close();
+
+    // legacy: flowData が変換生成され、reactFlowData は保持される (両テーブル)
+    for (const record of [tplLegacy, sesLegacy]) {
+      expect(record.reactFlowData).toBe(legacyReactFlow);
+      const parsed = FlowDataSchema.parse(JSON.parse(record.flowData));
+      expect(parsed.sections.length).toBeGreaterThan(0);
+      expect(parsed.sections[0].steps[0].title).toBe("開始");
+    }
+
+    // already-new: 既存の flowData がそのまま保持される (両テーブル)
+    for (const record of [tplNew, sesNew]) {
+      expect(record.flowData).toBe(existingFlow);
+      expect(record.reactFlowData).toBe(legacyReactFlow);
+    }
+  });
+});

--- a/frontend/src/db/models/GameSession.test.ts
+++ b/frontend/src/db/models/GameSession.test.ts
@@ -1,6 +1,10 @@
 import { createTestSession } from "#test/factories";
 import { describe, test, expect, spyOn } from "bun:test";
 
+import type { FlowData } from "@/flow/schema";
+
+import { defaultFlowData } from "@/flow/schema";
+
 import { defaultReactFlowData } from "../schemas";
 
 describe("GameSession", () => {
@@ -135,6 +139,48 @@ describe("GameSession", () => {
       consoleSpy.mockRestore();
 
       expect(parsed).toEqual(defaultReactFlowData);
+    });
+  });
+
+  describe("flowData", () => {
+    test("createTestSessionはdefaultFlowDataを持つ", async () => {
+      const session = await createTestSession({});
+
+      expect(session.getParsedFlowData()).toEqual(defaultFlowData);
+    });
+
+    test("flowDataをZodバリデーション付きで更新する", async () => {
+      const session = await createTestSession({});
+      const flowData: FlowData = {
+        version: 1,
+        sections: [{ id: "s1", title: "S1", memo: "", collapsed: false, steps: [] }],
+      };
+
+      await session.update({ flowData });
+
+      expect(session.getParsedFlowData()).toEqual(flowData);
+    });
+
+    test("flowDataのバリデーションが失敗した場合はエラーをスローする", async () => {
+      const session = await createTestSession({});
+
+      const invalidData = { version: 2 } as unknown as Parameters<
+        typeof session.update
+      >[0]["flowData"];
+
+      expect(session.update({ flowData: invalidData })).rejects.toThrow();
+    });
+
+    test("無効なJSONの場合はdefaultFlowDataを返す", async () => {
+      const session = await createTestSession({});
+
+      session.flowData = "not valid json";
+
+      const consoleSpy = spyOn(console, "error").mockImplementation(() => {});
+      const parsed = session.getParsedFlowData();
+      consoleSpy.mockRestore();
+
+      expect(parsed).toEqual(defaultFlowData);
     });
   });
 });

--- a/frontend/src/db/models/GameSession.test.ts
+++ b/frontend/src/db/models/GameSession.test.ts
@@ -164,7 +164,7 @@ describe("GameSession", () => {
     test("flowDataのバリデーションが失敗した場合はエラーをスローする", async () => {
       const session = await createTestSession({});
 
-      const invalidData = { version: 2 } as unknown as Parameters<
+      const invalidData = { version: 1, sections: "nope" } as unknown as Parameters<
         typeof session.update
       >[0]["flowData"];
 

--- a/frontend/src/db/models/GameSession.ts
+++ b/frontend/src/db/models/GameSession.ts
@@ -1,5 +1,9 @@
 import { Entity } from "dexie";
 
+import type { FlowData } from "@/flow/schema";
+
+import { FlowDataSchema, defaultFlowData } from "@/flow/schema";
+
 import type { DB } from "../database";
 
 import { db } from "../instance";
@@ -19,6 +23,7 @@ export class GameSession extends Entity<DB> {
   readonly botId!: string;
   gameFlags!: string; // JSON encoded string
   reactFlowData!: string; // JSON encoded string
+  flowData!: string; // JSON encoded string
   readonly createdAt!: Date;
   lastUsedAt!: Date;
 
@@ -30,8 +35,9 @@ export class GameSession extends Entity<DB> {
     name?: string;
     gameFlags?: GameFlags;
     reactFlowData?: ReactFlowData;
+    flowData?: FlowData;
   }): Promise<void> {
-    const { name, gameFlags, reactFlowData } = options;
+    const { name, gameFlags, reactFlowData, flowData } = options;
 
     const updateData: Partial<GameSessionData> = {
       lastUsedAt: new Date(),
@@ -51,6 +57,11 @@ export class GameSession extends Entity<DB> {
       updateData.reactFlowData = JSON.stringify(reactFlowData);
     }
 
+    if (flowData !== undefined) {
+      FlowDataSchema.parse(flowData);
+      updateData.flowData = JSON.stringify(flowData);
+    }
+
     await db.GameSession.update(this.id, updateData);
 
     if (name !== undefined) {
@@ -61,6 +72,9 @@ export class GameSession extends Entity<DB> {
     }
     if (reactFlowData !== undefined) {
       this.reactFlowData = JSON.stringify(reactFlowData);
+    }
+    if (flowData !== undefined) {
+      this.flowData = JSON.stringify(flowData);
     }
     if (updateData.lastUsedAt) {
       this.lastUsedAt = updateData.lastUsedAt;
@@ -84,6 +98,16 @@ export class GameSession extends Entity<DB> {
     } catch (error) {
       console.error("Failed to parse reactFlowData:", error);
       return defaultReactFlowData;
+    }
+  }
+
+  getParsedFlowData(): FlowData {
+    try {
+      const parsed = JSON.parse(this.flowData);
+      return FlowDataSchema.parse(parsed);
+    } catch (error) {
+      console.error("Failed to parse flowData:", error);
+      return defaultFlowData;
     }
   }
 }

--- a/frontend/src/db/models/Template.test.ts
+++ b/frontend/src/db/models/Template.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, spyOn } from "bun:test";
 
+import type { FlowData } from "@/flow/schema";
+
+import { defaultFlowData } from "@/flow/schema";
+
 import { defaultReactFlowData } from "../schemas";
 import { Template } from "./Template";
 
@@ -127,6 +131,48 @@ describe("Template", () => {
       consoleSpy.mockRestore();
 
       expect(parsed).toEqual(defaultReactFlowData);
+    });
+  });
+
+  describe("flowData", () => {
+    test("create時にdefaultFlowDataが設定される", async () => {
+      const template = await Template.create("Test");
+
+      expect(template.getParsedFlowData()).toEqual(defaultFlowData);
+    });
+
+    test("flowDataをZodバリデーション付きで更新する", async () => {
+      const template = await Template.create("Test");
+      const flowData: FlowData = {
+        version: 1,
+        sections: [{ id: "s1", title: "S1", memo: "", collapsed: false, steps: [] }],
+      };
+
+      await template.update({ flowData });
+
+      expect(template.getParsedFlowData()).toEqual(flowData);
+    });
+
+    test("flowDataのバリデーションが失敗した場合はエラーをスローする", async () => {
+      const template = await Template.create("Test");
+
+      const invalidData = { version: 2 } as unknown as Parameters<
+        typeof template.update
+      >[0]["flowData"];
+
+      expect(template.update({ flowData: invalidData })).rejects.toThrow();
+    });
+
+    test("無効なJSONの場合はdefaultFlowDataを返す", async () => {
+      const template = await Template.create("Test");
+
+      template.flowData = "not valid json";
+
+      const consoleSpy = spyOn(console, "error").mockImplementation(() => {});
+      const parsed = template.getParsedFlowData();
+      consoleSpy.mockRestore();
+
+      expect(parsed).toEqual(defaultFlowData);
     });
   });
 

--- a/frontend/src/db/models/Template.test.ts
+++ b/frontend/src/db/models/Template.test.ts
@@ -156,7 +156,7 @@ describe("Template", () => {
     test("flowDataのバリデーションが失敗した場合はエラーをスローする", async () => {
       const template = await Template.create("Test");
 
-      const invalidData = { version: 2 } as unknown as Parameters<
+      const invalidData = { version: 1, sections: "nope" } as unknown as Parameters<
         typeof template.update
       >[0]["flowData"];
 
@@ -193,6 +193,32 @@ describe("Template", () => {
 
       expect(template.name).toBe("Imported Template");
       expect(template.getParsedGameFlags()).toEqual({ key: "value" });
+    });
+
+    test("reactFlowDataからflowDataを導出して保存する", async () => {
+      const exportData = {
+        version: 1,
+        name: "Imported",
+        gameFlags: {},
+        reactFlowData: {
+          nodes: [
+            {
+              id: "n1",
+              type: "SetGameFlag",
+              position: { x: 0, y: 0 },
+              data: { title: "A", flagKey: "k", flagValue: "v" },
+            },
+          ],
+          edges: [],
+          viewport: { x: 0, y: 0, zoom: 1 },
+        },
+      };
+
+      const template = await Template.import(exportData);
+
+      const flowData = template.getParsedFlowData();
+      expect(flowData.sections.length).toBeGreaterThan(0);
+      expect(flowData.sections[0].steps[0].title).toBe("A");
     });
 
     test("サポートされていないバージョンの場合はエラーをスローする", async () => {

--- a/frontend/src/db/models/Template.ts
+++ b/frontend/src/db/models/Template.ts
@@ -1,5 +1,9 @@
 import { Entity } from "dexie";
 
+import type { FlowData } from "@/flow/schema";
+
+import { FlowDataSchema, defaultFlowData } from "@/flow/schema";
+
 import type { DB } from "../database";
 
 import { db } from "../instance";
@@ -19,6 +23,7 @@ export class Template extends Entity<DB> {
   name!: string;
   gameFlags!: string; // JSON encoded string
   reactFlowData!: string; // JSON encoded string
+  flowData!: string; // JSON encoded string
   readonly createdAt!: Date;
   updatedAt!: Date;
 
@@ -27,6 +32,7 @@ export class Template extends Entity<DB> {
       name: name.trim(),
       gameFlags: JSON.stringify({}),
       reactFlowData: JSON.stringify(defaultReactFlowData),
+      flowData: JSON.stringify(defaultFlowData),
       createdAt: new Date(),
       updatedAt: new Date(),
     });
@@ -50,8 +56,9 @@ export class Template extends Entity<DB> {
     name?: string;
     gameFlags?: GameFlags;
     reactFlowData?: ReactFlowData;
+    flowData?: FlowData;
   }): Promise<void> {
-    const { name, gameFlags, reactFlowData } = options;
+    const { name, gameFlags, reactFlowData, flowData } = options;
 
     const updateData: Partial<TemplateData> = {
       updatedAt: new Date(),
@@ -71,6 +78,11 @@ export class Template extends Entity<DB> {
       updateData.reactFlowData = JSON.stringify(reactFlowData);
     }
 
+    if (flowData !== undefined) {
+      FlowDataSchema.parse(flowData);
+      updateData.flowData = JSON.stringify(flowData);
+    }
+
     await db.Template.update(this.id, updateData);
 
     if (name !== undefined) {
@@ -81,6 +93,9 @@ export class Template extends Entity<DB> {
     }
     if (reactFlowData !== undefined) {
       this.reactFlowData = JSON.stringify(reactFlowData);
+    }
+    if (flowData !== undefined) {
+      this.flowData = JSON.stringify(flowData);
     }
     if (updateData.updatedAt) {
       this.updatedAt = updateData.updatedAt;
@@ -108,6 +123,16 @@ export class Template extends Entity<DB> {
     } catch (error) {
       console.error("Failed to parse reactFlowData:", error);
       return defaultReactFlowData;
+    }
+  }
+
+  getParsedFlowData(): FlowData {
+    try {
+      const parsed = JSON.parse(this.flowData);
+      return FlowDataSchema.parse(parsed);
+    } catch (error) {
+      console.error("Failed to parse flowData:", error);
+      return defaultFlowData;
     }
   }
 

--- a/frontend/src/db/models/Template.ts
+++ b/frontend/src/db/models/Template.ts
@@ -2,6 +2,7 @@ import { Entity } from "dexie";
 
 import type { FlowData } from "@/flow/schema";
 
+import { reactFlowToFlowData } from "@/flow/migrate";
 import { FlowDataSchema, defaultFlowData } from "@/flow/schema";
 
 import type { DB } from "../database";
@@ -153,9 +154,13 @@ export class Template extends Entity<DB> {
     }
 
     const template = await Template.create(validated.name);
+    // flowData は reactFlowData から導出する (両者のファイルパスは常に一致させる)。
+    // インポート経路のパス書き換え (files/ → template/{id}/) は fileSystem.ts の
+    // importTemplate が reactFlowData / flowData 双方に対して行う。
     await template.update({
       gameFlags: validated.gameFlags,
       reactFlowData: validated.reactFlowData,
+      flowData: reactFlowToFlowData(validated.reactFlowData),
     });
 
     return template;

--- a/frontend/src/db/schemas.ts
+++ b/frontend/src/db/schemas.ts
@@ -74,6 +74,7 @@ const GameSessionSchema = z.object({
   botId: z.string().nonempty().trim(),
   gameFlags: z.string(), // JSON encoded
   reactFlowData: z.string(), // JSON encoded
+  flowData: z.string(), // JSON encoded (issue #182 step-list editor)
   createdAt: z.date(),
   lastUsedAt: z.date(),
 });
@@ -83,6 +84,7 @@ const TemplateSchema = z.object({
   name: z.string().nonempty().trim(),
   gameFlags: z.string(), // JSON encoded
   reactFlowData: z.string(), // JSON encoded
+  flowData: z.string(), // JSON encoded (issue #182 step-list editor)
   createdAt: z.date(),
   updatedAt: z.date(),
 });

--- a/frontend/src/fileSystem.ts
+++ b/frontend/src/fileSystem.ts
@@ -8,6 +8,7 @@ import {
 } from "@zip.js/zip.js";
 
 import { db, Template, type ReactFlowData } from "./db";
+import { convertFilePathsInFlowData } from "./flow/filePaths";
 
 type Attachment = { filePath: string };
 type MessageWithAttachments = { attachments: Attachment[] };
@@ -211,9 +212,9 @@ export class FileSystem {
       await this.writeFile(targetPath, file);
     }
 
-    // Rewrite filePaths in reactFlowData to point to the new template ID
-    const oldReactFlowData = template.getParsedReactFlowData();
-    const newReactFlowData = convertFilePathsInReactFlowData(oldReactFlowData, (filePath) => {
+    // Rewrite filePaths to point to the new template ID. reactFlowData / flowData は
+    // パスを共有するため同じ replacer で両方書き換える。
+    const replaceFilePath = (filePath: string) => {
       if (filePath.startsWith("files/")) {
         return `template/${newId}/${filePath.slice("files/".length)}`;
       }
@@ -221,8 +222,13 @@ export class FileSystem {
         return `template/${newId}/${filePath.slice(`template/${oldTemplateId}/`.length)}`;
       }
       return filePath;
-    });
-    await template.update({ reactFlowData: newReactFlowData });
+    };
+    const newReactFlowData = convertFilePathsInReactFlowData(
+      template.getParsedReactFlowData(),
+      replaceFilePath,
+    );
+    const newFlowData = convertFilePathsInFlowData(template.getParsedFlowData(), replaceFilePath);
+    await template.update({ reactFlowData: newReactFlowData, flowData: newFlowData });
 
     return template;
   }

--- a/frontend/src/flow/convert.ts
+++ b/frontend/src/flow/convert.ts
@@ -12,7 +12,7 @@ import { FlowDataSchema, StepSchema } from "./schema";
 // 分岐は最近共通合流点 (immediate post-dominator) を検出して branches[].steps にネストし、
 // 変換しきれない構造は捨てずにフラット化 + ⚠️ メモと警告で手直しを促す。
 
-type ConversionWarning = {
+export type ConversionWarning = {
   message: string;
   nodeId?: string;
 };

--- a/frontend/src/flow/filePaths.test.ts
+++ b/frontend/src/flow/filePaths.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+
+import type { FlowData } from "./schema";
+
+import { convertFilePathsInFlowData } from "./filePaths";
+import { FlowDataSchema } from "./schema";
+
+const flow = (sections: unknown[]): FlowData => FlowDataSchema.parse({ version: 1, sections });
+
+const attachment = (filePath: string) => ({ fileName: "f.png", filePath, fileSize: 1 });
+
+const sendMessage = (id: string, filePath: string) => ({
+  id,
+  type: "SendMessage",
+  title: id,
+  channelTargets: [{ type: "channelName", value: "general" }],
+  messages: [{ content: "hi", attachments: [attachment(filePath)] }],
+});
+
+const replacer = (p: string) => p.replace("template/1/", "session/9/");
+
+describe("convertFilePathsInFlowData", () => {
+  test("SendMessage の attachments のパスを書き換える", () => {
+    const input = flow([{ id: "s1", title: "S1", steps: [sendMessage("m1", "template/1/a.png")] }]);
+
+    const result = convertFilePathsInFlowData(input, replacer);
+
+    const step = result.sections[0].steps[0];
+    if (step.type !== "SendMessage") throw new Error("expected SendMessage");
+    expect(step.messages[0].attachments[0].filePath).toBe("session/9/a.png");
+    // 入力は変更しない
+    const original = input.sections[0].steps[0];
+    if (original.type !== "SendMessage") throw new Error("expected SendMessage");
+    expect(original.messages[0].attachments[0].filePath).toBe("template/1/a.png");
+  });
+
+  test("CombinationSendMessage の entries 内メッセージのパスを書き換える", () => {
+    const input = flow([
+      {
+        id: "s1",
+        title: "S1",
+        steps: [
+          {
+            id: "c1",
+            type: "CombinationSendMessage",
+            title: "C1",
+            entries: [
+              {
+                id: "e1",
+                channelName: "general",
+                messages: [{ content: "x", attachments: [attachment("template/1/b.png")] }],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const result = convertFilePathsInFlowData(input, replacer);
+
+    const step = result.sections[0].steps[0];
+    if (step.type !== "CombinationSendMessage") throw new Error("expected CombinationSendMessage");
+    expect(step.entries[0].messages[0].attachments[0].filePath).toBe("session/9/b.png");
+  });
+
+  test("Branch の arm 内ネスト SendMessage のパスも書き換える", () => {
+    const input = flow([
+      {
+        id: "s1",
+        title: "S1",
+        steps: [
+          {
+            id: "br1",
+            type: "Branch",
+            title: "分岐",
+            mode: "select",
+            flagName: "f",
+            branches: [{ id: "arm1", label: "A", steps: [sendMessage("m1", "template/1/c.png")] }],
+          },
+        ],
+      },
+    ]);
+
+    const result = convertFilePathsInFlowData(input, replacer);
+
+    const branch = result.sections[0].steps[0];
+    if (branch.type !== "Branch") throw new Error("expected Branch");
+    const nested = branch.branches[0].steps[0];
+    if (nested.type !== "SendMessage") throw new Error("expected SendMessage");
+    expect(nested.messages[0].attachments[0].filePath).toBe("session/9/c.png");
+  });
+
+  test("ファイルを持たないステップはそのまま返す", () => {
+    const input = flow([
+      {
+        id: "s1",
+        title: "S1",
+        steps: [{ id: "f1", type: "SetGameFlag", title: "F1", flagKey: "k", flagValue: "v" }],
+      },
+    ]);
+
+    const result = convertFilePathsInFlowData(input, replacer);
+
+    expect(result.sections[0].steps[0]).toEqual(input.sections[0].steps[0]);
+  });
+});

--- a/frontend/src/flow/filePaths.ts
+++ b/frontend/src/flow/filePaths.ts
@@ -1,0 +1,50 @@
+import type { FlowData, Step } from "./schema";
+
+// FlowData 内の添付ファイルパスを書き換える。reactFlowData 側の
+// convertFilePathsInReactFlowData (fileSystem.ts) と対の関数で、セッション作成や
+// テンプレートインポート時に template/{id}/ ↔ session/{id}/ ↔ files/ のパスを移し替える。
+// SendMessage / CombinationSendMessage の attachments[].filePath を対象とし、Branch は
+// branches[].steps へ再帰する。
+export function convertFilePathsInFlowData(
+  flowData: FlowData,
+  replacer: (filePath: string) => string,
+): FlowData {
+  const convertStep = (step: Step): Step => {
+    if (step.type === "SendMessage") {
+      return {
+        ...step,
+        messages: step.messages.map((message) => ({
+          ...message,
+          attachments: message.attachments.map((a) => ({ ...a, filePath: replacer(a.filePath) })),
+        })),
+      };
+    }
+    if (step.type === "CombinationSendMessage") {
+      return {
+        ...step,
+        entries: step.entries.map((entry) => ({
+          ...entry,
+          messages: entry.messages.map((message) => ({
+            ...message,
+            attachments: message.attachments.map((a) => ({ ...a, filePath: replacer(a.filePath) })),
+          })),
+        })),
+      };
+    }
+    if (step.type === "Branch") {
+      return {
+        ...step,
+        branches: step.branches.map((arm) => ({ ...arm, steps: arm.steps.map(convertStep) })),
+      };
+    }
+    return step;
+  };
+
+  return {
+    ...flowData,
+    sections: flowData.sections.map((section) => ({
+      ...section,
+      steps: section.steps.map(convertStep),
+    })),
+  };
+}

--- a/frontend/src/flow/migrate.test.ts
+++ b/frontend/src/flow/migrate.test.ts
@@ -197,10 +197,12 @@ describe("migrateRecordToFlowData", () => {
     expect(parsed.sections[0].steps[0].title).toBe("D");
   });
 
-  test("reactFlowData が壊れた JSON なら defaultFlowData を返す", () => {
+  test("reactFlowData が壊れた JSON なら警告メモ付きの空フローにフォールバックする", () => {
     const result = silencingErrors(() => migrateRecordToFlowData("not json", undefined));
 
-    expect(JSON.parse(result)).toEqual(defaultFlowData);
+    const parsed = FlowDataSchema.parse(JSON.parse(result));
+    const memos = parsed.sections.map((s) => s.memo).join("\n");
+    expect(memos).toContain("不正な JSON");
   });
 
   test("reactFlowData が有効 JSON だが非グラフなら空フロー + 警告にフォールバックする", () => {

--- a/frontend/src/flow/migrate.test.ts
+++ b/frontend/src/flow/migrate.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 
 import type { FlowData } from "./schema";
 
-import { foldWarningsIntoFlowData, migrateRecordToFlowData } from "./migrate";
+import { foldWarningsIntoFlowData, migrateRecordToFlowData, reactFlowToFlowData } from "./migrate";
 import { FlowDataSchema, defaultFlowData } from "./schema";
 
 // ---- フィクスチャ ----
@@ -31,6 +31,16 @@ const sgNode = (id: string, title: string) => ({
   data: { title, flagKey: "k", flagValue: "v" },
 });
 
+// console.error を黙らせつつ fn を実行する (フォールバック経路のログ汚染を防ぐ)
+const silencingErrors = <T>(fn: () => T): T => {
+  const spy = spyOn(console, "error").mockImplementation(() => {});
+  try {
+    return fn();
+  } finally {
+    spy.mockRestore();
+  }
+};
+
 describe("foldWarningsIntoFlowData", () => {
   test("warnings が空なら入力をそのまま (同一参照で) 返す", () => {
     const input = flow([{ id: "s1", title: "S1", steps: [setFlagStep("st1")] }]);
@@ -45,6 +55,17 @@ describe("foldWarningsIntoFlowData", () => {
     expect(result.sections[0].steps[0].memo).toBe("⚠️ 危険");
     // 入力は変更しない (純粋)
     expect(input.sections[0].steps[0].memo).toBe("");
+  });
+
+  test("同一ステップへの複数警告は \\n\\n 区切りで追記し既存内容を保つ", () => {
+    const input = flow([{ id: "s1", title: "S1", steps: [setFlagStep("st1")] }]);
+
+    const result = foldWarningsIntoFlowData(input, [
+      { nodeId: "st1", message: "A" },
+      { nodeId: "st1", message: "B" },
+    ]);
+
+    expect(result.sections[0].steps[0].memo).toBe("⚠️ A\n\n⚠️ B");
   });
 
   test("Branch の arm 内ネストステップにも追記する", () => {
@@ -72,6 +93,18 @@ describe("foldWarningsIntoFlowData", () => {
     expect(branch.branches[0].steps[0].memo).toBe("⚠️ 深部");
   });
 
+  test("nodeId がセクション id に一致する警告は当該セクションの memo に追記する", () => {
+    const input = flow([
+      { id: "s1", title: "S1", steps: [] },
+      { id: "s2", title: "S2", steps: [] },
+    ]);
+
+    const result = foldWarningsIntoFlowData(input, [{ nodeId: "s2", message: "区間警告" }]);
+
+    expect(result.sections[1].memo).toBe("⚠️ 区間警告");
+    expect(result.sections[0].memo).toBe("");
+  });
+
   test("nodeId 無し / 不一致の警告は先頭セクションの memo に集約する", () => {
     const input = flow([{ id: "s1", title: "S1", steps: [setFlagStep("st1")] }]);
 
@@ -87,6 +120,15 @@ describe("foldWarningsIntoFlowData", () => {
     expect(result.sections[0].steps[0].memo).toBe("");
   });
 
+  test("集約先セクションに既存 memo があれば \\n\\n 区切りで保持して追記する", () => {
+    const input = flow([{ id: "s1", title: "S1", memo: "既存メモ", steps: [] }]);
+
+    const result = foldWarningsIntoFlowData(input, [{ message: "孤立警告" }]);
+
+    expect(result.sections[0].memo.startsWith("既存メモ\n\n⚠️ 変換時の警告:")).toBe(true);
+    expect(result.sections[0].memo).toContain("- 孤立警告");
+  });
+
   test("セクションが無い場合は受け皿セクションを作って集約する", () => {
     const input = flow([]);
 
@@ -95,6 +137,21 @@ describe("foldWarningsIntoFlowData", () => {
     expect(result.sections).toHaveLength(1);
     expect(result.sections[0].id).toBe("conversion-warnings");
     expect(result.sections[0].memo).toContain("孤立警告");
+  });
+});
+
+describe("reactFlowToFlowData", () => {
+  test("グラフを FlowData へ変換する", () => {
+    const result = reactFlowToFlowData(rfGraph([sgNode("n1", "A")]));
+
+    expect(result.sections[0].steps[0].title).toBe("A");
+  });
+
+  test("変換が throw する入力 (有効 JSON だが非グラフ) は空フロー + 警告メモにフォールバックする", () => {
+    const result = silencingErrors(() => reactFlowToFlowData(42));
+
+    const memos = result.sections.map((s) => s.memo).join("\n");
+    expect(memos).toContain("変換できなかった");
   });
 });
 
@@ -132,23 +189,48 @@ describe("migrateRecordToFlowData", () => {
   });
 
   test("既存 flowData が壊れていれば reactFlowData から再構築する", () => {
-    const result = migrateRecordToFlowData(
-      JSON.stringify(rfGraph([sgNode("n1", "D")])),
-      "{壊れた json",
+    const result = silencingErrors(() =>
+      migrateRecordToFlowData(JSON.stringify(rfGraph([sgNode("n1", "D")])), "{壊れた json"),
     );
 
     const parsed = FlowDataSchema.parse(JSON.parse(result));
     expect(parsed.sections[0].steps[0].title).toBe("D");
   });
 
-  test("reactFlowData が壊れていれば defaultFlowData を返す", () => {
-    const result = migrateRecordToFlowData("not json", undefined);
+  test("reactFlowData が壊れた JSON なら defaultFlowData を返す", () => {
+    const result = silencingErrors(() => migrateRecordToFlowData("not json", undefined));
 
     expect(JSON.parse(result)).toEqual(defaultFlowData);
   });
 
+  test("reactFlowData が有効 JSON だが非グラフなら空フロー + 警告にフォールバックする", () => {
+    const result = silencingErrors(() => migrateRecordToFlowData("42", undefined));
+
+    const parsed = FlowDataSchema.parse(JSON.parse(result));
+    const memos = parsed.sections.map((s) => s.memo).join("\n");
+    expect(memos).toContain("変換できなかった");
+  });
+
+  test("reactFlowData が欠落 (undefined) なら defaultFlowData を返す", () => {
+    const result = migrateRecordToFlowData(undefined, undefined);
+
+    expect(JSON.parse(result)).toEqual(defaultFlowData);
+  });
+
+  test("変換結果を再度マイグレートしても変化しない (冪等)", () => {
+    // 警告を伴うグラフ (Bogus ノード混在) で、畳み込み済みメモが再検証を通り
+    // already-new 短絡に乗る = 二重畳み込みが起きないことを確認する
+    const legacy = JSON.stringify(
+      rfGraph([sgNode("n1", "A"), { id: "x1", type: "Bogus", position: { x: 0, y: 0 }, data: {} }]),
+    );
+
+    const once = migrateRecordToFlowData(legacy, undefined);
+    const twice = migrateRecordToFlowData(legacy, once);
+
+    expect(twice).toBe(once);
+  });
+
   test("converter の warnings を flowData のメモへ畳み込む", () => {
-    // 未知ノードのみ → ステップ化されず警告のみ → 受け皿セクションへ集約される
     const result = migrateRecordToFlowData(
       JSON.stringify(rfGraph([{ id: "x1", type: "Bogus", position: { x: 0, y: 0 }, data: {} }])),
       undefined,

--- a/frontend/src/flow/migrate.test.ts
+++ b/frontend/src/flow/migrate.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+
+import type { FlowData } from "./schema";
+
+import { foldWarningsIntoFlowData, migrateRecordToFlowData } from "./migrate";
+import { FlowDataSchema, defaultFlowData } from "./schema";
+
+// ---- フィクスチャ ----
+
+const flow = (sections: unknown[]): FlowData => FlowDataSchema.parse({ version: 1, sections });
+
+const setFlagStep = (id: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  type: "SetGameFlag",
+  title: id,
+  flagKey: "k",
+  flagValue: "v",
+  ...extra,
+});
+
+const rfGraph = (nodes: unknown[], edges: unknown[] = []) => ({
+  nodes,
+  edges,
+  viewport: { x: 0, y: 0, zoom: 1 },
+});
+
+const sgNode = (id: string, title: string) => ({
+  id,
+  type: "SetGameFlag",
+  position: { x: 0, y: 0 },
+  data: { title, flagKey: "k", flagValue: "v" },
+});
+
+describe("foldWarningsIntoFlowData", () => {
+  test("warnings が空なら入力をそのまま (同一参照で) 返す", () => {
+    const input = flow([{ id: "s1", title: "S1", steps: [setFlagStep("st1")] }]);
+    expect(foldWarningsIntoFlowData(input, [])).toBe(input);
+  });
+
+  test("nodeId が一致するステップの memo に ⚠️ 付きで追記する", () => {
+    const input = flow([{ id: "s1", title: "S1", steps: [setFlagStep("st1")] }]);
+
+    const result = foldWarningsIntoFlowData(input, [{ nodeId: "st1", message: "危険" }]);
+
+    expect(result.sections[0].steps[0].memo).toBe("⚠️ 危険");
+    // 入力は変更しない (純粋)
+    expect(input.sections[0].steps[0].memo).toBe("");
+  });
+
+  test("Branch の arm 内ネストステップにも追記する", () => {
+    const input = flow([
+      {
+        id: "s1",
+        title: "S1",
+        steps: [
+          {
+            id: "br1",
+            type: "Branch",
+            title: "分岐",
+            mode: "select",
+            flagName: "f",
+            branches: [{ id: "arm1", label: "A", steps: [setFlagStep("nested1")] }],
+          },
+        ],
+      },
+    ]);
+
+    const result = foldWarningsIntoFlowData(input, [{ nodeId: "nested1", message: "深部" }]);
+
+    const branch = result.sections[0].steps[0];
+    if (branch.type !== "Branch") throw new Error("expected Branch");
+    expect(branch.branches[0].steps[0].memo).toBe("⚠️ 深部");
+  });
+
+  test("nodeId 無し / 不一致の警告は先頭セクションの memo に集約する", () => {
+    const input = flow([{ id: "s1", title: "S1", steps: [setFlagStep("st1")] }]);
+
+    const result = foldWarningsIntoFlowData(input, [
+      { message: "全体警告" },
+      { nodeId: "unknown", message: "未一致" },
+    ]);
+
+    expect(result.sections[0].memo).toContain("⚠️ 変換時の警告:");
+    expect(result.sections[0].memo).toContain("- 全体警告");
+    expect(result.sections[0].memo).toContain("- 未一致");
+    // ステップ memo は変更されない
+    expect(result.sections[0].steps[0].memo).toBe("");
+  });
+
+  test("セクションが無い場合は受け皿セクションを作って集約する", () => {
+    const input = flow([]);
+
+    const result = foldWarningsIntoFlowData(input, [{ message: "孤立警告" }]);
+
+    expect(result.sections).toHaveLength(1);
+    expect(result.sections[0].id).toBe("conversion-warnings");
+    expect(result.sections[0].memo).toContain("孤立警告");
+  });
+});
+
+describe("migrateRecordToFlowData", () => {
+  test("legacy な reactFlowData を変換して flowData JSON 文字列を返す", () => {
+    const result = migrateRecordToFlowData(JSON.stringify(rfGraph([sgNode("n1", "A")])), undefined);
+
+    const parsed = FlowDataSchema.parse(JSON.parse(result));
+    expect(parsed.sections).toHaveLength(1);
+    expect(parsed.sections[0].steps[0].title).toBe("A");
+  });
+
+  test("reactFlowData がオブジェクト (非文字列) でも変換する", () => {
+    const result = migrateRecordToFlowData(rfGraph([sgNode("n1", "B")]), undefined);
+
+    const parsed = FlowDataSchema.parse(JSON.parse(result));
+    expect(parsed.sections[0].steps[0].title).toBe("B");
+  });
+
+  test("already-new: 妥当な flowData はそのまま返し reactFlowData を無視する", () => {
+    const existing = JSON.stringify(
+      flow([{ id: "keep", title: "既存", steps: [setFlagStep("st1")] }]),
+    );
+
+    const result = migrateRecordToFlowData("これは壊れた reactFlowData", existing);
+
+    expect(result).toBe(existing);
+  });
+
+  test("空文字の flowData は already-new とみなさず reactFlowData から変換する", () => {
+    const result = migrateRecordToFlowData(JSON.stringify(rfGraph([sgNode("n1", "C")])), "");
+
+    const parsed = FlowDataSchema.parse(JSON.parse(result));
+    expect(parsed.sections[0].steps[0].title).toBe("C");
+  });
+
+  test("既存 flowData が壊れていれば reactFlowData から再構築する", () => {
+    const result = migrateRecordToFlowData(
+      JSON.stringify(rfGraph([sgNode("n1", "D")])),
+      "{壊れた json",
+    );
+
+    const parsed = FlowDataSchema.parse(JSON.parse(result));
+    expect(parsed.sections[0].steps[0].title).toBe("D");
+  });
+
+  test("reactFlowData が壊れていれば defaultFlowData を返す", () => {
+    const result = migrateRecordToFlowData("not json", undefined);
+
+    expect(JSON.parse(result)).toEqual(defaultFlowData);
+  });
+
+  test("converter の warnings を flowData のメモへ畳み込む", () => {
+    // 未知ノードのみ → ステップ化されず警告のみ → 受け皿セクションへ集約される
+    const result = migrateRecordToFlowData(
+      JSON.stringify(rfGraph([{ id: "x1", type: "Bogus", position: { x: 0, y: 0 }, data: {} }])),
+      undefined,
+    );
+
+    const parsed = FlowDataSchema.parse(JSON.parse(result));
+    const memos = parsed.sections.map((s) => s.memo).join("\n");
+    expect(memos).toContain("未知のノード型");
+  });
+});

--- a/frontend/src/flow/migrate.ts
+++ b/frontend/src/flow/migrate.ts
@@ -79,8 +79,9 @@ export function foldWarningsIntoFlowData(
 // メモへ畳み込む。変換が throw した場合 (例: 形が不正で ConvertInputSchema が ZodError、
 // または converter のバグ) は、空フローを無言で返さず、ログを残しつつ警告メモ付きの
 // 空フローにフォールバックする (本 PR の「捨てずに surface」方針)。
-// upgrade トランザクション内で呼ばれるため再 throw しない (throw すると DB の version
-// 移行ごと中断し、アプリが開けなくなる)。
+// migration の upgrade トランザクションと Template.import の両方から呼ばれる。再 throw
+// しないのは、upgrade では DB の version 移行ごと中断してアプリが開けなくなり、import では
+// Template.create 済みの半端なレコードが取り残されるため。失敗はログ + メモで surface する。
 export function reactFlowToFlowData(input: unknown): FlowData {
   try {
     const { flowData, warnings } = convertReactFlowToFlowData(input ?? {});
@@ -99,7 +100,8 @@ export function reactFlowToFlowData(input: unknown): FlowData {
 // レコード 1 件に保存する flowData JSON 文字列を決める。
 // - 既に妥当な flowData を持つ (already-new) なら冪等にそのまま返す
 // - それ以外は reactFlowData を変換して返す (警告はメモへ畳み込み済み)
-// - reactFlowData が JSON として壊れていれば空の defaultFlowData にフォールバック
+// - reactFlowData が JSON として壊れていれば、警告メモ付きの空フローにフォールバック
+//   (変換失敗時と同じく「捨てずに surface」する)
 export function migrateRecordToFlowData(reactFlowData: unknown, existingFlowData: unknown): string {
   if (typeof existingFlowData === "string" && existingFlowData !== "") {
     try {
@@ -116,7 +118,14 @@ export function migrateRecordToFlowData(reactFlowData: unknown, existingFlowData
     input = typeof reactFlowData === "string" ? JSON.parse(reactFlowData) : reactFlowData;
   } catch (error) {
     console.error("flowData migration: reactFlowData が不正な JSON です", error);
-    return JSON.stringify(defaultFlowData);
+    const detail = error instanceof Error ? error.message : String(error);
+    return JSON.stringify(
+      foldWarningsIntoFlowData(defaultFlowData, [
+        {
+          message: `reactFlowData が不正な JSON のため空のフローにフォールバックしました: ${detail}`,
+        },
+      ]),
+    );
   }
 
   return JSON.stringify(reactFlowToFlowData(input));

--- a/frontend/src/flow/migrate.ts
+++ b/frontend/src/flow/migrate.ts
@@ -1,0 +1,113 @@
+import type { Transaction } from "dexie";
+
+import type { FlowData, Step } from "./schema";
+
+import { convertReactFlowToFlowData } from "./convert";
+import { FlowDataSchema, defaultFlowData } from "./schema";
+
+// reactFlowData → flowData の Dexie マイグレーション (issue #182 Phase 1)。
+// 変換そのものは convert.ts、ここは「レコード 1 件をどう flowData 文字列にするか」と
+// 「Dexie トランザクションで両テーブルを書き換える」までを担う純粋ロジック。
+// database.ts の version(7).upgrade はこのモジュールを呼ぶだけの薄いラッパー。
+
+type ConversionWarning = ReturnType<typeof convertReactFlowToFlowData>["warnings"][number];
+
+const WARNING_PREFIX = "⚠️";
+
+const appendMemo = (memo: string, text: string) => (memo === "" ? text : `${memo}\n\n${text}`);
+
+// branches[].steps を含めて全ステップを id で引けるよう再帰的に索引する
+function indexStepsById(flowData: FlowData): Map<string, Step> {
+  const byId = new Map<string, Step>();
+  const visit = (step: Step) => {
+    byId.set(step.id, step);
+    if (step.type !== "Branch") return;
+    for (const arm of step.branches) for (const child of arm.steps) visit(child);
+  };
+  for (const section of flowData.sections) for (const step of section.steps) visit(step);
+  return byId;
+}
+
+// converter の warnings を FlowData 内のメモへ畳み込み、UI 未整備の段階でも喪失させない。
+// nodeId がステップに一致する警告はそのステップ memo へ、残り (グローバル警告・未実体化
+// グループ等) は先頭セクション memo へ集約する。セクションが無ければ受け皿を 1 つ作る。
+export function foldWarningsIntoFlowData(
+  flowData: FlowData,
+  warnings: ConversionWarning[],
+): FlowData {
+  if (warnings.length === 0) return flowData;
+
+  const next = structuredClone(flowData);
+  const stepsById = indexStepsById(next);
+  const leftover: string[] = [];
+
+  for (const warning of warnings) {
+    const step = warning.nodeId === undefined ? undefined : stepsById.get(warning.nodeId);
+    if (step) {
+      step.memo = appendMemo(step.memo, `${WARNING_PREFIX} ${warning.message}`);
+    } else {
+      leftover.push(warning.message);
+    }
+  }
+
+  if (leftover.length > 0) {
+    const block = `${WARNING_PREFIX} 変換時の警告:\n${leftover.map((m) => `- ${m}`).join("\n")}`;
+    if (next.sections.length === 0) {
+      next.sections.push({
+        id: "conversion-warnings",
+        title: "変換時の警告",
+        memo: block,
+        collapsed: false,
+        steps: [],
+      });
+    } else {
+      next.sections[0].memo = appendMemo(next.sections[0].memo, block);
+    }
+  }
+
+  return next;
+}
+
+// レコード 1 件に保存する flowData JSON 文字列を決める。
+// - 既に妥当な flowData を持つ (already-new) なら冪等にそのまま返す
+// - それ以外は reactFlowData を変換し、warnings を畳み込んで返す
+// - reactFlowData が壊れている / 変換不能なら空の defaultFlowData にフォールバック
+export function migrateRecordToFlowData(reactFlowData: unknown, existingFlowData: unknown): string {
+  if (typeof existingFlowData === "string" && existingFlowData !== "") {
+    try {
+      FlowDataSchema.parse(JSON.parse(existingFlowData));
+      return existingFlowData;
+    } catch {
+      // 壊れた既存 flowData は信用せず reactFlowData から再構築する
+    }
+  }
+
+  let input: unknown;
+  try {
+    input = typeof reactFlowData === "string" ? JSON.parse(reactFlowData) : reactFlowData;
+  } catch {
+    return JSON.stringify(defaultFlowData);
+  }
+
+  try {
+    const { flowData, warnings } = convertReactFlowToFlowData(input ?? {});
+    return JSON.stringify(foldWarningsIntoFlowData(flowData, warnings));
+  } catch {
+    return JSON.stringify(defaultFlowData);
+  }
+}
+
+type MigratableRecord = { reactFlowData?: string; flowData?: string };
+
+// Template / GameSession 両テーブルへ flowData を付与する。reactFlowData は保持。
+// version(7).upgrade から呼ばれる実体。両テーブルが同じ純粋変換を共有する。
+export async function applyFlowDataMigration(tx: Transaction): Promise<void> {
+  for (const tableName of ["Template", "GameSession"]) {
+    await tx
+      .table(tableName)
+      .toCollection()
+      .modify((record: MigratableRecord) => {
+        record.flowData = migrateRecordToFlowData(record.reactFlowData, record.flowData);
+      });
+  }
+}

--- a/frontend/src/flow/migrate.ts
+++ b/frontend/src/flow/migrate.ts
@@ -1,16 +1,16 @@
 import type { Transaction } from "dexie";
 
+import type { ConversionWarning } from "./convert";
 import type { FlowData, Step } from "./schema";
 
 import { convertReactFlowToFlowData } from "./convert";
 import { FlowDataSchema, defaultFlowData } from "./schema";
 
 // reactFlowData → flowData の Dexie マイグレーション (issue #182 Phase 1)。
-// 変換そのものは convert.ts、ここは「レコード 1 件をどう flowData 文字列にするか」と
-// 「Dexie トランザクションで両テーブルを書き換える」までを担う純粋ロジック。
-// database.ts の version(7).upgrade はこのモジュールを呼ぶだけの薄いラッパー。
-
-type ConversionWarning = ReturnType<typeof convertReactFlowToFlowData>["warnings"][number];
+// 変換そのものは convert.ts。ここは純粋な変換ラッパー 3 種
+// (reactFlowToFlowData / foldWarningsIntoFlowData / migrateRecordToFlowData) と、
+// それを両テーブルへ適用する副作用 orchestrator (applyFlowDataMigration) を持つ。
+// database.ts の version(7).upgrade は applyFlowDataMigration を呼ぶだけ。
 
 const WARNING_PREFIX = "⚠️";
 
@@ -29,8 +29,9 @@ function indexStepsById(flowData: FlowData): Map<string, Step> {
 }
 
 // converter の warnings を FlowData 内のメモへ畳み込み、UI 未整備の段階でも喪失させない。
-// nodeId がステップに一致する警告はそのステップ memo へ、残り (グローバル警告・未実体化
-// グループ等) は先頭セクション memo へ集約する。セクションが無ければ受け皿を 1 つ作る。
+// nodeId がステップに一致→そのステップ memo、セクションに一致→そのセクション memo、
+// それ以外 (グローバル警告・未実体化グループ等) は先頭セクション memo へ集約する。
+// セクションが無ければ受け皿セクションを 1 つ作る。
 export function foldWarningsIntoFlowData(
   flowData: FlowData,
   warnings: ConversionWarning[],
@@ -39,15 +40,21 @@ export function foldWarningsIntoFlowData(
 
   const next = structuredClone(flowData);
   const stepsById = indexStepsById(next);
+  const sectionsById = new Map(next.sections.map((section) => [section.id, section]));
   const leftover: string[] = [];
 
   for (const warning of warnings) {
     const step = warning.nodeId === undefined ? undefined : stepsById.get(warning.nodeId);
     if (step) {
       step.memo = appendMemo(step.memo, `${WARNING_PREFIX} ${warning.message}`);
-    } else {
-      leftover.push(warning.message);
+      continue;
     }
+    const section = warning.nodeId === undefined ? undefined : sectionsById.get(warning.nodeId);
+    if (section) {
+      section.memo = appendMemo(section.memo, `${WARNING_PREFIX} ${warning.message}`);
+      continue;
+    }
+    leftover.push(warning.message);
   }
 
   if (leftover.length > 0) {
@@ -68,39 +75,58 @@ export function foldWarningsIntoFlowData(
   return next;
 }
 
+// reactFlowData (パース済みオブジェクト) を FlowData へ best-effort 変換し、warnings を
+// メモへ畳み込む。変換が throw した場合 (例: 形が不正で ConvertInputSchema が ZodError、
+// または converter のバグ) は、空フローを無言で返さず、ログを残しつつ警告メモ付きの
+// 空フローにフォールバックする (本 PR の「捨てずに surface」方針)。
+// upgrade トランザクション内で呼ばれるため再 throw しない (throw すると DB の version
+// 移行ごと中断し、アプリが開けなくなる)。
+export function reactFlowToFlowData(input: unknown): FlowData {
+  try {
+    const { flowData, warnings } = convertReactFlowToFlowData(input ?? {});
+    return foldWarningsIntoFlowData(flowData, warnings);
+  } catch (error) {
+    console.error("flowData migration: reactFlowData の変換に失敗しました", error);
+    const detail = error instanceof Error ? error.message : String(error);
+    return foldWarningsIntoFlowData(defaultFlowData, [
+      {
+        message: `reactFlowData を変換できなかったため空のフローにフォールバックしました: ${detail}`,
+      },
+    ]);
+  }
+}
+
 // レコード 1 件に保存する flowData JSON 文字列を決める。
 // - 既に妥当な flowData を持つ (already-new) なら冪等にそのまま返す
-// - それ以外は reactFlowData を変換し、warnings を畳み込んで返す
-// - reactFlowData が壊れている / 変換不能なら空の defaultFlowData にフォールバック
+// - それ以外は reactFlowData を変換して返す (警告はメモへ畳み込み済み)
+// - reactFlowData が JSON として壊れていれば空の defaultFlowData にフォールバック
 export function migrateRecordToFlowData(reactFlowData: unknown, existingFlowData: unknown): string {
   if (typeof existingFlowData === "string" && existingFlowData !== "") {
     try {
       FlowDataSchema.parse(JSON.parse(existingFlowData));
       return existingFlowData;
-    } catch {
-      // 壊れた既存 flowData は信用せず reactFlowData から再構築する
+    } catch (error) {
+      // 壊れた既存 flowData は信用せず reactFlowData から再構築する (ログは残す)
+      console.error("flowData migration: 既存 flowData が不正なため再構築します", error);
     }
   }
 
   let input: unknown;
   try {
     input = typeof reactFlowData === "string" ? JSON.parse(reactFlowData) : reactFlowData;
-  } catch {
+  } catch (error) {
+    console.error("flowData migration: reactFlowData が不正な JSON です", error);
     return JSON.stringify(defaultFlowData);
   }
 
-  try {
-    const { flowData, warnings } = convertReactFlowToFlowData(input ?? {});
-    return JSON.stringify(foldWarningsIntoFlowData(flowData, warnings));
-  } catch {
-    return JSON.stringify(defaultFlowData);
-  }
+  return JSON.stringify(reactFlowToFlowData(input));
 }
 
 type MigratableRecord = { reactFlowData?: string; flowData?: string };
 
-// Template / GameSession 両テーブルへ flowData を付与する。reactFlowData は保持。
-// version(7).upgrade から呼ばれる実体。両テーブルが同じ純粋変換を共有する。
+// Template / GameSession 両テーブルへ flowData を付与する副作用 orchestrator。
+// reactFlowData は保持。version(7).upgrade から呼ばれる実体で、両テーブルが同じ純粋
+// 変換 (migrateRecordToFlowData) を共有する。
 export async function applyFlowDataMigration(tx: Transaction): Promise<void> {
   for (const tableName of ["Template", "GameSession"]) {
     await tx

--- a/frontend/src/flow/schema.ts
+++ b/frontend/src/flow/schema.ts
@@ -299,3 +299,7 @@ export const FlowDataSchema = z.object({
 
 export type Step = z.infer<typeof StepSchema>;
 export type FlowData = z.infer<typeof FlowDataSchema>;
+
+// 空の FlowData。新規作成時の初期値、およびパース失敗時のフォールバック
+// (defaultReactFlowData と同じ役割)。
+export const defaultFlowData: FlowData = { version: 1, sections: [] };

--- a/frontend/test/factories.ts
+++ b/frontend/test/factories.ts
@@ -1,8 +1,10 @@
 import type { GameSession } from "@/db/models/GameSession";
 import type { ReactFlowData } from "@/db/schemas";
+import type { FlowData } from "@/flow/schema";
 
 import { db } from "@/db";
 import { defaultReactFlowData } from "@/db/schemas";
+import { defaultFlowData } from "@/flow/schema";
 
 interface SessionFactoryOptions {
   name?: string;
@@ -10,6 +12,7 @@ interface SessionFactoryOptions {
   botId?: string;
   gameFlags?: Record<string, unknown>;
   reactFlowData?: ReactFlowData;
+  flowData?: FlowData;
 }
 
 export async function createTestSession(options: SessionFactoryOptions = {}): Promise<GameSession> {
@@ -19,6 +22,7 @@ export async function createTestSession(options: SessionFactoryOptions = {}): Pr
     botId = "bot-456",
     gameFlags = {},
     reactFlowData = defaultReactFlowData,
+    flowData = defaultFlowData,
   } = options;
 
   const { GameSession } = await import("@/db/models/GameSession");
@@ -29,6 +33,7 @@ export async function createTestSession(options: SessionFactoryOptions = {}): Pr
     botId,
     gameFlags: JSON.stringify(gameFlags),
     reactFlowData: JSON.stringify(reactFlowData),
+    flowData: JSON.stringify(flowData),
     createdAt: new Date(),
     lastUsedAt: new Date(),
   });


### PR DESCRIPTION
## 概要

ステップリスト型エディタ移行 (issue #182) の **Phase 1: Dexie マイグレーション**。
`Template` / `GameSession` に `flowData` (JSON 文字列) を追加し、既存の `reactFlowData` を Dexie `version(7)` で一括変換する。`reactFlowData` は旧 UI + バックアップとして**保持**する (削除しない)。

正典: [`docs/dev/step-list-editor-architecture.md`](docs/dev/step-list-editor-architecture.md) の "Persistence & migration (Phase 1)"。

## 変更内容

### データモデル
- `db/schemas.ts`: `Template` / `GameSession` 両レコードに `flowData: z.string()`
- 両モデルクラスに `flowData` フィールド・`getParsedFlowData()`・`update({ flowData })` (既存 `reactFlowData` 経路と同形、parse 失敗時は `defaultFlowData` フォールバック)
- `flow/schema.ts`: 空の `defaultFlowData`

### マイグレーション (`flow/migrate.ts` 新規)
変換ロジックを純粋関数として切り出し、`database.ts` の `version(7).upgrade` はそれを呼ぶ薄いラッパーにした (`database.ts` は coverage 除外のため、テスト可能な純粋ロジックを分離)。

- `migrateRecordToFlowData` — レコード1件の変換。**冪等** (妥当な既存 `flowData` は保持 / 壊れていれば `reactFlowData` から再構築 / 変換不能は `defaultFlowData`)
- `foldWarningsIntoFlowData` — converter の `warnings` を `⚠️` メモへ畳み込み (nodeId 紐付き→該当ステップ memo、`branches[].steps` へ再帰。残り→先頭 or 受け皿セクション memo)。**何も捨てない**
- `applyFlowDataMigration` — 両テーブルを `modify()` で変換する実体

### 波及
- `Template.create` / `CreateSession.tsx` / `test/factories.ts` で `flowData` を初期化

### ドキュメント
- doc が Phase 1 で決めるとしていた「warnings の置き場所」の決定を canon に反映

## テスト
- `flow/migrate.test.ts` — 純粋ロジック網羅 (冪等性・warnings 畳み込み・各フォールバック)
- `db/flowDataMigration.test.ts` — 実 (fake-)IndexedDB 上で **v6→v7 統合**。両テーブル × legacy (flowData 未保持) / already-new (flowData 既保持) の 4 レコードで、legacy 変換・already-new 保持・`reactFlowData` 維持を検証
- モデルテストに `getParsedFlowData` / `update({flowData})` / 不正 JSON フォールバックを追加

## ゲート (全 green)
`bun run --bun test` (backend 48 / frontend 329 pass) · `typecheck` · `format` · `lint` · `bun run knip` すべて exit 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)