### PR TITLE
chore(deps): @playwright/test を 1.60.0 から 1.61.1 に更新

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -59,7 +59,7 @@
         "zustand": "5.0.14",
       },
       "devDependencies": {
-        "@playwright/test": "1.60.0",
+        "@playwright/test": "1.61.1",
         "@storybook/addon-docs": "10.3.5",
         "@storybook/addon-themes": "10.3.5",
         "@storybook/react-vite": "10.3.5",
@@ -421,7 +421,7 @@
 
     "@oxlint/win32-x64": ["@oxlint/win32-x64@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-XW1xqCj34MEGJlHteqasTZ/LmBrwYIgluhNW0aP+XWkn90+stKAq3W/40dvJKbMK9F7o09LPCuMVtUW7FIUuiA=="],
 
-    "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
@@ -951,9 +951,9 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
-    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
 
-    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "zustand": "5.0.14"
   },
   "devDependencies": {
-    "@playwright/test": "1.60.0",
+    "@playwright/test": "1.61.1",
     "@storybook/addon-docs": "10.3.5",
     "@storybook/addon-themes": "10.3.5",
     "@storybook/react-vite": "10.3.5",


### PR DESCRIPTION
## 概要
- `@playwright/test` を `1.60.0` → `1.61.1` に更新 (frontend/package.json devDependencies)
- 251コミット分の差分で、内部でChromiumバイナリが r1223 → r1228 にロールされている (browsers.json より確認)

## VRTベースライン再生成について
Chromiumバイナリのリビジョンが変わるため、`frontend/test/vrt/**/*-snapshots/*.png` のピクセル差分が
発生する可能性があった。CIの `vrt` job (`.github/workflows/ci.yml`) と同一手順でベースライン再生成を試みた:

1. `cd frontend && bun x playwright install --with-deps chromium`
2. `bun run --bun --filter gm-assistant-bot-frontend build-storybook`
3. `cd frontend && bun x playwright test --update-snapshots`

**手順1について**: 作業サンドボックス環境ではパスワードレスsudoが利用できず、
`--with-deps` (OS共有ライブラリのapt-getインストール) 部分が失敗した。ただし当該環境には
以前の作業で同種の共有ライブラリ (libnspr4, libnss3, libatk 等) が既にインストール済みであることを
`dpkg -l` で確認できたため、`bun x playwright install chromium` (OS依存パッケージのインストールを
伴わない、バイナリダウンロードのみのコマンド) で代替した。ダウンロードされたChromiumは
`playwright-core@1.61.1` の `browsers.json` が指定する **revision 1228** (CIの `--with-deps` でも
同一リビジョンがインストールされる) であり、実行結果 (後述) からも実害がないことを確認している。

**目視確認結果**: `playwright test --update-snapshots` 実行後、`git status` で
`frontend/test/vrt/**/*-snapshots/*.png` の変更は **0件**。既存ベースライン (Chromium r1223 で生成) と
新しいChromium r1228 の描画結果はピクセル単位で完全一致しており、ベースライン更新は不要だった。
(直近コミットのような baseline 再生成コミットは今回は発生していない)

## テスト結果
- `bun run --bun test`: 全591件 pass (backend 48 / frontend 543)
- `bun run --bun typecheck`: エラーなし
- `bun run --bun lint`: エラーなし
- `bun run knip`: 既存の設定ヒントのみ (本変更と無関係)
- `bun x playwright test --update-snapshots` (VRT, chromium 3プロジェクト×ライト/ダーク): 186 passed, 14 skipped, 0 failed

## Test plan
- [x] `bun run --bun test`
- [x] `bun run --bun typecheck`
- [x] `bun run --bun lint`
- [x] `bun run knip`
- [x] VRT (`playwright test --update-snapshots`) — スナップショット差分0件を確認