### PR TITLE
docs: フロントエンド UI 変更の実挙動検証用 verify スキルを追加

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: verify
+description: Verify frontend UI changes end-to-end by driving Storybook stories with Playwright + the pre-installed Chromium. Use after changing flow editor / node UI components to observe real runtime behavior (clicks, drags, renders) instead of relying on unit tests alone.
+---
+
+# Verify frontend UI changes via Storybook + Playwright
+
+## Launch Storybook (dev server)
+
+```bash
+cd frontend && nohup bun run storybook --ci > /tmp/storybook.log 2>&1 &
+# wait until: curl -s -o /dev/null -w "%{http_code}" http://localhost:6006/iframe.html?id=<story-id>&viewMode=story  => 200 (~6s)
+```
+
+Gotchas:
+
+- **Do NOT use `bun run --bun storybook`** — forcing the Bun runtime breaks
+  Storybook's CLI arg parsing (`Invariant failed: expected options to have a port`).
+  Plain `bun run storybook` runs the binary under its node shebang and works.
+- Storybook writes `frontend/debug-storybook.log` on errors — delete it before committing.
+
+## Story URLs
+
+Stories live in `frontend/test/stories/`. Direct iframe URL (no manager UI):
+`http://localhost:6006/iframe.html?id=<kebab-title>--<story>&viewMode=story`
+e.g. `flow-steplistpanel--default`. Stories seed the Zustand stores themselves,
+so no IndexedDB/app setup is needed — this is the cheapest handle on flow-editor UI.
+
+## Drive with Playwright
+
+Write a script and run it with `bun <script>.ts` importing from `@playwright/test`
+(resolved from `frontend/`, so run with cwd=frontend or keep the script's imports resolvable):
+
+```ts
+import { chromium } from "@playwright/test";
+// The repo pins a @playwright/test version whose browser build may not match the
+// pre-installed set — always pass executablePath:
+const browser = await chromium.launch({ executablePath: "/opt/pw-browsers/chromium" });
+```
+
+Gotchas:
+
+- `page.waitForSelector("li")` matches Storybook's *hidden* error-template
+  `<li>Please check the Storybook config.</li>` and times out. Wait for real
+  content instead: `page.getByText("<known row title>").waitFor()`.
+- dnd-kit's PointerSensor has `activationConstraint: { distance: 5 }` — after
+  `mouse.down()`, make a small move (>5px) first, then move to the target in
+  steps, then `mouse.up()`. `keyboard.press("Escape")` mid-drag cancels.
+
+## Running the repo's VRT suite locally (remote/sandbox environments)
+
+`bun run --bun test:vrt` needs Playwright's own browser revisions. If the
+pinned @playwright/test expects a revision the environment doesn't have
+(`Executable doesn't exist at /opt/pw-browsers/chromium_headless_shell-<rev>/...`),
+shim it instead of downloading (`playwright install` is blocked/unnecessary):
+
+```bash
+# full chromium: layout matches across revisions — a directory symlink suffices
+ln -sfn /opt/pw-browsers/chromium-<have> /opt/pw-browsers/chromium-<want>
+# headless shell: layout differs (chrome-linux/headless_shell vs
+# chrome-headless-shell-linux64/chrome-headless-shell) — bridge both names
+mkdir -p /opt/pw-browsers/chromium_headless_shell-<want>
+ln -sfn /opt/pw-browsers/chromium_headless_shell-<have>/chrome-linux \
+  /opt/pw-browsers/chromium_headless_shell-<want>/chrome-headless-shell-linux64
+ln -sfn headless_shell \
+  /opt/pw-browsers/chromium_headless_shell-<have>/chrome-linux/chrome-headless-shell
+```
+
+Storybook stories must be built first (`bun run --bun build-storybook`); the
+vite dev server on :3000 is started by the Playwright webServer config.


### PR DESCRIPTION
## 概要

フロントエンド UI 変更をユニットテストだけでなく**実挙動**で検証するための手順を `.claude/skills/verify/SKILL.md` として追加します。PR #200（セクション跨ぎのステップ並び替え）の検証作業で確立したレシピの切り出しです（#200 の議論を受けて別 PR 化）。

## 内容

Storybook ストーリーを Playwright + 環境同梱の Chromium で駆動して、クリック・ドラッグ・描画を end-to-end で観察する手順:

- Storybook dev サーバーの起動方法と、`bun run --bun storybook` だと CLI の引数解析が壊れて起動しない件（`Invariant failed: expected options to have a port`）
- ストーリーの iframe 直接 URL と、ストーリーが Zustand store を自前でシードするため追加セットアップ不要である点
- Playwright 駆動時の注意点:
  - リポジトリ pin の @playwright/test と同梱ブラウザのリビジョン不一致には `executablePath: "/opt/pw-browsers/chromium"` で対応
  - `waitForSelector("li")` が Storybook の隠しエラーテンプレートに誤マッチしてタイムアウトする件
  - dnd-kit PointerSensor（`activationConstraint: distance 5`）をマウスイベントで駆動する方法
- VRT スイートをローカル/サンドボックス環境で回すためのブラウザリビジョンのシム手順

## 影響範囲

ドキュメントのみ。アプリコード・テスト・CI への変更はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEwXnXXY5xYWqa2x6HkPeM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEwXnXXY5xYWqa2x6HkPeM)_