### PR TITLE
chore: ponytail プラグイン有効化と ccweb セットアップ hook 削除

### DIFF
--- a/.claude/scripts/setup-ccweb.sh
+++ b/.claude/scripts/setup-ccweb.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-: "${CLAUDE_ENV_FILE:?CLAUDE_ENV_FILE must be set}"
-: "${CLAUDE_PROJECT_DIR:?CLAUDE_PROJECT_DIR must be set}"
-
-source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-export PATH="/nix/var/nix/profiles/default/bin:$PATH"
-( cd "$CLAUDE_PROJECT_DIR" && devbox shellenv --init-hook=false ) > "$CLAUDE_ENV_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,30 +7,12 @@
       "Write(**/.env*)",
       "Read(**/.dev.vars)",
       "Edit(**/.dev.vars)",
-      "Write(**/.dev.vars)"
+      "Write(**/.dev.vars)",
+      "Edit(**.lock)",
+      "Write(**.lock)"
     ]
   },
   "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "if [ \"$CLAUDE_CODE_REMOTE\" = \"true\" ]; then bash \"$CLAUDE_PROJECT_DIR/.claude/scripts/setup-ccweb.sh\"; else direnv export bash > \"$CLAUDE_ENV_FILE\"; fi"
-          }
-        ]
-      }
-    ],
-    "CwdChanged": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "if [ \"$CLAUDE_CODE_REMOTE\" = \"true\" ]; then bash \"$CLAUDE_PROJECT_DIR/.claude/scripts/setup-ccweb.sh\"; else direnv export bash > \"$CLAUDE_ENV_FILE\"; fi"
-          }
-        ]
-      }
-    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
@@ -46,6 +28,7 @@
   },
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
-    "frontend-design@claude-plugins-official": true
+    "frontend-design@claude-plugins-official": true,
+    "ponytail@ponytail": true
   }
 }


### PR DESCRIPTION
## Summary
- ponytail プラグインを有効化
- devbox 環境が直接使えるようになったため、SessionStart/CwdChanged hook と `.claude/scripts/setup-ccweb.sh` (リモート判定での direnv/ccweb 切り替え) を削除
- lock ファイル (`**.lock`) への誤った Edit/Write を防ぐ deny ルールを追加

## Test plan
- [ ] Claude Code を起動し、devbox 環境が問題なくロードされることを確認
- [ ] `.lock` ファイルへの Edit/Write が拒否されることを確認