### PR TITLE
SetGameFlag のフラグ名・値を候補から選択できるようにする

### DIFF
--- a/frontend/src/flow/components/DatalistInput.tsx
+++ b/frontend/src/flow/components/DatalistInput.tsx
@@ -1,0 +1,44 @@
+import { useId } from "react";
+
+// 候補からの選択と自由入力を両立するコンボボックス (input + datalist)。
+// PortaledSelect (選択のみ) と違い、候補に無い新しい値も入力できる。
+// datalist のポップアップはブラウザネイティブ UI のため CSS transform の影響を受けない。
+
+interface DatalistInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: string[];
+  placeholder?: string;
+  className?: string;
+}
+
+export const DatalistInput = ({
+  value,
+  onChange,
+  options,
+  placeholder,
+  className,
+}: DatalistInputProps) => {
+  const listId = useId();
+  const hasOptions = options.length > 0;
+
+  return (
+    <>
+      <input
+        type="text"
+        className={className ?? "input w-full"}
+        list={hasOptions ? listId : undefined}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+      />
+      {hasOptions && (
+        <datalist id={listId}>
+          {options.map((option) => (
+            <option key={option} value={option} />
+          ))}
+        </datalist>
+      )}
+    </>
+  );
+};

--- a/frontend/src/flow/components/DatalistInput.tsx
+++ b/frontend/src/flow/components/DatalistInput.tsx
@@ -1,9 +1,6 @@
 import { useId } from "react";
 
-// 候補からの選択と自由入力を両立するコンボボックス (input + datalist)。
-// PortaledSelect (選択のみ) と違い、候補に無い新しい値も入力できる。
 // datalist のポップアップはブラウザネイティブ UI のため CSS transform の影響を受けない。
-
 interface DatalistInputProps {
   value: string;
   onChange: (value: string) => void;

--- a/frontend/src/flow/components/DetailPanel.tsx
+++ b/frontend/src/flow/components/DetailPanel.tsx
@@ -14,10 +14,15 @@ import { findStep } from "../treeOps";
 export const DetailPanel = () => {
   const selectedStepId = useEditorStore((state) => state.selectedStepId);
   const flowData = useEditorStore((state) => state.flowData);
+  const gameFlags = useEditorStore((state) => state.gameFlags);
   const updateStep = useEditorStore((state) => state.updateStep);
 
-  // フィールドエディタ (ResourceSelector 等) が候補表示に使うリソースを flowData から供給する。
-  const resources = useMemo(() => collectResourcesFromFlow(flowData), [flowData]);
+  // フィールドエディタ (ResourceSelector 等) が候補表示に使うリソースを flowData と
+  // seed gameFlags (フラグパネル) から供給する。
+  const resources = useMemo(
+    () => collectResourcesFromFlow(flowData, gameFlags),
+    [flowData, gameFlags],
+  );
   const step = selectedStepId === null ? undefined : findStep(flowData, selectedStepId);
 
   if (step === undefined) {

--- a/frontend/src/flow/components/FlagPanel.tsx
+++ b/frontend/src/flow/components/FlagPanel.tsx
@@ -1,14 +1,7 @@
 import { useState } from "react";
 
+import { formatFlagValue } from "../resources";
 import { useEditorStore } from "../store/editorStore";
-
-// gameFlags の値は z.any() なので unknown。表示用に安全に文字列化する。
-const formatFlagValue = (value: unknown): string => {
-  if (value === null || value === undefined) return "";
-  if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean") return String(value);
-  return JSON.stringify(value);
-};
 
 // D3: 常駐するゲームフラグパネル (右カラム)。
 // edit モードでは Template.gameFlags (セッション開始時の seed) を編集する。

--- a/frontend/src/flow/registry/SetGameFlag.tsx
+++ b/frontend/src/flow/registry/SetGameFlag.tsx
@@ -1,30 +1,43 @@
+import { useMemo } from "react";
+
+import { useTemplateResources } from "@/components/Node/utils/useTemplateResources";
+
+import { DatalistInput } from "../components/DatalistInput";
+import { collectFlagKeyOptions, collectFlagValueOptions } from "../resources";
 import { SetGameFlagStepSchema, type SetGameFlagStep } from "../schema";
 import { defineStep, type DetailPanelProps } from "./types";
 
-const SetGameFlagDetailPanel = ({ step, onChange }: DetailPanelProps<SetGameFlagStep>) => (
-  <div className="flex flex-col gap-3">
-    <fieldset className="fieldset">
-      <legend className="fieldset-legend">フラグ名</legend>
-      <input
-        type="text"
-        className="input w-full"
-        value={step.flagKey}
-        onChange={(evt) => onChange({ flagKey: evt.target.value })}
-        placeholder="例: アイテム入手, イベント発生済み"
-      />
-    </fieldset>
-    <fieldset className="fieldset">
-      <legend className="fieldset-legend">値</legend>
-      <input
-        type="text"
-        className="input w-full"
-        value={step.flagValue}
-        onChange={(evt) => onChange({ flagValue: evt.target.value })}
-        placeholder="例: 1, アイテム名"
-      />
-    </fieldset>
-  </div>
-);
+const SetGameFlagDetailPanel = ({ step, onChange }: DetailPanelProps<SetGameFlagStep>) => {
+  const resources = useTemplateResources(step.id);
+  const keyOptions = useMemo(() => collectFlagKeyOptions(resources), [resources]);
+  const valueOptions = useMemo(
+    () => collectFlagValueOptions(resources, step.flagKey),
+    [resources, step.flagKey],
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <fieldset className="fieldset">
+        <legend className="fieldset-legend">フラグ名</legend>
+        <DatalistInput
+          value={step.flagKey}
+          onChange={(flagKey) => onChange({ flagKey })}
+          options={keyOptions}
+          placeholder="例: アイテム入手, イベント発生済み"
+        />
+      </fieldset>
+      <fieldset className="fieldset">
+        <legend className="fieldset-legend">値</legend>
+        <DatalistInput
+          value={step.flagValue}
+          onChange={(flagValue) => onChange({ flagValue })}
+          options={valueOptions}
+          placeholder="例: 1, アイテム名"
+        />
+      </fieldset>
+    </div>
+  );
+};
 
 export const SetGameFlagEntry = defineStep<SetGameFlagStep>({
   type: "SetGameFlag",

--- a/frontend/src/flow/resources.test.ts
+++ b/frontend/src/flow/resources.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test";
 
 import type { FlowData } from "./schema";
 
-import { collectResourcesFromFlow } from "./resources";
+import {
+  collectFlagKeyOptions,
+  collectFlagValueOptions,
+  collectResourcesFromFlow,
+  formatFlagValue,
+} from "./resources";
 
 const flow: FlowData = {
   version: 1,
@@ -199,5 +204,68 @@ describe("collectResourcesFromFlow (auto モード分岐)", () => {
 
   test("auto モードでも枝内のステップは再帰的に収集する", () => {
     expect(resources.gameFlags.some((flag) => flag.key === "innerFlag")).toBe(true);
+  });
+});
+
+describe("collectResourcesFromFlow (gameFlags マージ)", () => {
+  const resources = collectResourcesFromFlow(flow, {
+    seedOnly: "初期値",
+    phase: "day",
+    count: 3,
+    "  ": "空白キーはスキップ",
+    empty: "",
+  });
+
+  test("フラグパネル由来のキーを候補に含める", () => {
+    expect(resources.gameFlags.some((flag) => flag.key === "seedOnly")).toBe(true);
+  });
+
+  test("非文字列の値も文字列化して values に載せる", () => {
+    expect(resources.gameFlags.find((flag) => flag.key === "count")?.values).toEqual(["3"]);
+  });
+
+  test("空白キーはスキップ・空値は values に載せない", () => {
+    expect(resources.gameFlags.some((flag) => flag.key.trim() === "")).toBe(false);
+    expect(resources.gameFlags.find((flag) => flag.key === "empty")?.values).toEqual([]);
+  });
+
+  test("ステップ由来のフラグと共存する (phase は seed とステップの両方から)", () => {
+    expect(resources.gameFlags.filter((flag) => flag.key === "phase")).toHaveLength(2);
+  });
+});
+
+describe("collectFlagKeyOptions / collectFlagValueOptions", () => {
+  const resources = collectResourcesFromFlow(flow, { phase: "day" });
+
+  test("キー候補は重複を除いて列挙する", () => {
+    const options = collectFlagKeyOptions(resources);
+    expect(options.filter((key) => key === "phase")).toHaveLength(1);
+    expect(options.sort()).toEqual(
+      ["assign_t1", "assign_t2", "phase", "round", "vote", "winner"].sort(),
+    );
+  });
+
+  test("値候補は指定キーの値のみを重複を除いて列挙する", () => {
+    expect(collectFlagValueOptions(resources, "phase").sort()).toEqual(["day", "night"].sort());
+    expect(collectFlagValueOptions(resources, "vote")).toEqual(["賛成", "反対"]);
+  });
+
+  test("キー未入力・未知キーの値候補は空", () => {
+    expect(collectFlagValueOptions(resources, "")).toEqual([]);
+    expect(collectFlagValueOptions(resources, "unknown")).toEqual([]);
+  });
+});
+
+describe("formatFlagValue", () => {
+  test("null / undefined は空文字列", () => {
+    expect(formatFlagValue(null)).toBe("");
+    expect(formatFlagValue(undefined)).toBe("");
+  });
+
+  test("プリミティブは String 化・それ以外は JSON 化", () => {
+    expect(formatFlagValue("a")).toBe("a");
+    expect(formatFlagValue(3)).toBe("3");
+    expect(formatFlagValue(true)).toBe("true");
+    expect(formatFlagValue({ a: 1 })).toBe('{"a":1}');
   });
 });

--- a/frontend/src/flow/resources.ts
+++ b/frontend/src/flow/resources.ts
@@ -2,17 +2,12 @@ import type { TemplateResources } from "@/components/Node/utils/collectResources
 
 import type { FlowData, Step } from "./schema";
 
-// gameFlags (Template seed / GameSession live) の値は z.any() なので unknown。
-// 表示・候補用に安全に文字列化する。
 export const formatFlagValue = (value: unknown): string => {
   if (value === null || value === undefined) return "";
   if (typeof value === "string") return value;
   if (typeof value === "number" || typeof value === "boolean") return String(value);
   return JSON.stringify(value);
 };
-
-// フラグパネル由来のフラグ (ステップ以外) を示す sourceNodeId。
-const GAME_FLAGS_SOURCE_ID = "game-flags";
 
 // FlowData ツリーから、フィールドエディタ (ResourceSelector / FlagValueSelector /
 // DynamicValueInput) が候補表示に使う TemplateResources を集める。
@@ -94,7 +89,7 @@ export const collectResourcesFromFlow = (
     const k = key.trim();
     if (k === "") continue;
     const v = formatFlagValue(value).trim();
-    resources.gameFlags.push({ key: k, values: v ? [v] : [], sourceNodeId: GAME_FLAGS_SOURCE_ID });
+    resources.gameFlags.push({ key: k, values: v ? [v] : [], sourceNodeId: "game-flags" });
   }
   for (const section of flow.sections) {
     for (const step of section.steps) collectFromStep(step, resources);
@@ -104,17 +99,9 @@ export const collectResourcesFromFlow = (
 
 // ---- フィールドエディタ向けの候補リスト (PURE / unit-tested) ----
 
-export const collectFlagKeyOptions = (resources: TemplateResources): string[] => {
-  const seen = new Set<string>();
-  const options: string[] = [];
-  for (const flag of resources.gameFlags) {
-    const key = flag.key.trim();
-    if (key === "" || seen.has(key)) continue;
-    seen.add(key);
-    options.push(key);
-  }
-  return options;
-};
+export const collectFlagKeyOptions = (resources: TemplateResources): string[] => [
+  ...new Set(resources.gameFlags.map((f) => f.key.trim()).filter((k) => k !== "")),
+];
 
 export const collectFlagValueOptions = (
   resources: TemplateResources,
@@ -122,16 +109,11 @@ export const collectFlagValueOptions = (
 ): string[] => {
   const key = flagKey.trim();
   if (key === "") return [];
-  const seen = new Set<string>();
-  const options: string[] = [];
-  for (const flag of resources.gameFlags) {
-    if (flag.key.trim() !== key) continue;
-    for (const rawValue of flag.values) {
-      const value = rawValue.trim();
-      if (value === "" || seen.has(value)) continue;
-      seen.add(value);
-      options.push(value);
-    }
-  }
-  return options;
+  return [
+    ...new Set(
+      resources.gameFlags
+        .filter((f) => f.key.trim() === key)
+        .flatMap((f) => f.values.map((v) => v.trim()).filter((v) => v !== "")),
+    ),
+  ];
 };

--- a/frontend/src/flow/resources.ts
+++ b/frontend/src/flow/resources.ts
@@ -2,6 +2,18 @@ import type { TemplateResources } from "@/components/Node/utils/collectResources
 
 import type { FlowData, Step } from "./schema";
 
+// gameFlags (Template seed / GameSession live) の値は z.any() なので unknown。
+// 表示・候補用に安全に文字列化する。
+export const formatFlagValue = (value: unknown): string => {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return JSON.stringify(value);
+};
+
+// フラグパネル由来のフラグ (ステップ以外) を示す sourceNodeId。
+const GAME_FLAGS_SOURCE_ID = "game-flags";
+
 // FlowData ツリーから、フィールドエディタ (ResourceSelector / FlagValueSelector /
 // DynamicValueInput) が候補表示に使う TemplateResources を集める。
 // React Flow 版の collectResourcesBeforeNode の flowData 版。edit モードでは順序を厳密に
@@ -71,10 +83,55 @@ const collectFromStep = (step: Step, resources: TemplateResources): void => {
   }
 };
 
-export const collectResourcesFromFlow = (flow: FlowData): TemplateResources => {
+// gameFlags には edit モードでは Template.gameFlags (seed)、execute モードでは
+// GameSession.gameFlags (live) を渡す。フラグパネルで定義しただけのフラグも候補に載せる。
+export const collectResourcesFromFlow = (
+  flow: FlowData,
+  gameFlags?: Record<string, unknown>,
+): TemplateResources => {
   const resources: TemplateResources = { roles: [], channels: [], gameFlags: [] };
+  for (const [key, value] of Object.entries(gameFlags ?? {})) {
+    const k = key.trim();
+    if (k === "") continue;
+    const v = formatFlagValue(value).trim();
+    resources.gameFlags.push({ key: k, values: v ? [v] : [], sourceNodeId: GAME_FLAGS_SOURCE_ID });
+  }
   for (const section of flow.sections) {
     for (const step of section.steps) collectFromStep(step, resources);
   }
   return resources;
+};
+
+// ---- フィールドエディタ向けの候補リスト (PURE / unit-tested) ----
+
+export const collectFlagKeyOptions = (resources: TemplateResources): string[] => {
+  const seen = new Set<string>();
+  const options: string[] = [];
+  for (const flag of resources.gameFlags) {
+    const key = flag.key.trim();
+    if (key === "" || seen.has(key)) continue;
+    seen.add(key);
+    options.push(key);
+  }
+  return options;
+};
+
+export const collectFlagValueOptions = (
+  resources: TemplateResources,
+  flagKey: string,
+): string[] => {
+  const key = flagKey.trim();
+  if (key === "") return [];
+  const seen = new Set<string>();
+  const options: string[] = [];
+  for (const flag of resources.gameFlags) {
+    if (flag.key.trim() !== key) continue;
+    for (const rawValue of flag.values) {
+      const value = rawValue.trim();
+      if (value === "" || seen.has(value)) continue;
+      seen.add(value);
+      options.push(value);
+    }
+  }
+  return options;
 };

--- a/frontend/src/flow/runner/RunnerDetailPanel.tsx
+++ b/frontend/src/flow/runner/RunnerDetailPanel.tsx
@@ -20,10 +20,15 @@ import { RunnerToolPanel } from "./RunnerToolPanel";
 export const RunnerDetailPanel = ({ handlers }: { handlers: RunHandlers }) => {
   const selectedStepId = useRunnerStore((state) => state.selectedStepId);
   const flowData = useRunnerStore((state) => state.flowData);
+  const gameFlags = useRunnerStore((state) => state.gameFlags);
   const updateStep = useRunnerStore((state) => state.updateStep);
   const runningStepId = useRunnerStore((state) => state.runningStepId);
 
-  const resources = useMemo(() => collectResourcesFromFlow(flowData), [flowData]);
+  // ライブの session gameFlags も候補に含める (edit モードの seed に対応)。
+  const resources = useMemo(
+    () => collectResourcesFromFlow(flowData, gameFlags),
+    [flowData, gameFlags],
+  );
   const step = selectedStepId === null ? undefined : findStep(flowData, selectedStepId);
 
   if (step === undefined) {


### PR DESCRIPTION
## Summary
- SetGameFlag の詳細パネルで、フラグ名と値を候補 (`<datalist>`) から選択できるようにする。候補に無い新規値の入力も可能
- フラグパネルで seed 定義しただけのフラグ、および execute モード時のセッション live gameFlags も候補ソースに含める
- `collectFlagKeyOptions` / `collectFlagValueOptions` / `formatFlagValue` を `resources.ts` に集約 (pure helper・unit test 付き)

## Test plan
- [ ] `bun test src/flow/resources.test.ts` が pass
- [ ] edit モードでフラグパネルに手動追加した seed フラグが SetGameFlag のフラグ名候補に出る
- [ ] SetGameFlag ステップで別途定義したフラグ名/値が候補として引き継がれる
- [ ] execute モードで進行中セッションの live gameFlags が候補に出る
- [ ] 候補に無い値も自由入力できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)