### PR TITLE
chore: settings.json の Write deny を削除

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,12 +4,9 @@
     "deny": [
       "Read(**/.env*)",
       "Edit(**/.env*)",
-      "Write(**/.env*)",
       "Read(**/.dev.vars)",
       "Edit(**/.dev.vars)",
-      "Write(**/.dev.vars)",
-      "Edit(**.lock)",
-      "Write(**.lock)"
+      "Edit(**.lock)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary
- `.env` / `.dev.vars` / `*.lock` への `Write` deny ルールを削除
- Claude Code の warning 抑止が目的
- `Read` / `Edit` の deny は継続

## Test plan
- [ ] Claude Code 実行時に該当ファイルの warning が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)