### PR TITLE
SetGameFlag に実行時の選択肢を追加 (edit で用意し execute で選択)

### DIFF
--- a/docs/dev/step-list-editor-architecture.md
+++ b/docs/dev/step-list-editor-architecture.md
@@ -97,7 +97,7 @@ export interface StepRegistryEntry<S extends Step = Step> {
   schema: z.ZodType<S>;                      // re-export the per-type schema from flow/schema.ts
   defaults: () => Omit<S, "id">;             // for "add step" (replaces the addNode switch)
   summary: (step: S) => string;              // PURE. one-line list-row text. unit-tested.
-  DetailPanel: (props: { step: S; onChange: (patch: Partial<S>) => void }) => JSX.Element;
+  DetailPanel: (props: { step: S; onChange: (patch: Partial<S>) => void; mode?: "edit" | "execute" }) => JSX.Element;
   category: "action" | "tool" | "branch";    // tool = flag-only UI, no Discord call (see Tools)
   execute?: (step: S, ctx: ExecuteContext) => Promise<ExecuteResult>; // PURE-ish. omit for tools.
 }
@@ -116,7 +116,9 @@ Rules:
   This is the autonomous-verification lever: both are unit-tested without rendering.
 - `DetailPanel` is a dumb controlled component: it receives `step` + `onChange(patch)` and
   reuses existing field editors (D2). It does **not** touch the store directly — the host
-  (`DetailPanel.tsx`) wires `onChange` to `treeOps.updateStepById`.
+  (`DetailPanel.tsx`) wires `onChange` to `treeOps.updateStepById`. The runner host passes
+  `mode="execute"` (default `"edit"`); a panel may branch on it to swap authoring UI for a
+  runtime picker (e.g. `SetGameFlag` renders its prepared options as a `<select>`).
 - Branch is just another entry; its `DetailPanel` renders nested `<StepList>` per arm and its
   `execute()` returns which arm(s) to descend into (the engine handles recursion — see Engine).
 - **Tools** (`Kanban`, `Counter`, `ShuffleAssign`, `RandomSelect`, `RecordCombination`) have

--- a/frontend/src/flow/registry/SetGameFlag.test.ts
+++ b/frontend/src/flow/registry/SetGameFlag.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { SetGameFlagStep } from "../schema";
 
+import { SetGameFlagStepSchema } from "../schema";
 import { SetGameFlagEntry } from "./SetGameFlag";
 
 const makeStep = (overrides: Partial<SetGameFlagStep> = {}): SetGameFlagStep => ({
@@ -12,7 +13,25 @@ const makeStep = (overrides: Partial<SetGameFlagStep> = {}): SetGameFlagStep => 
   autoAdvance: false,
   flagKey: "",
   flagValue: "",
+  flagKeyOptions: [],
+  flagValueOptions: [],
   ...overrides,
+});
+
+describe("SetGameFlagStepSchema", () => {
+  test("選択肢フィールドを持たない旧データは空配列で補完される", () => {
+    const parsed = SetGameFlagStepSchema.parse({
+      id: "step-1",
+      type: "SetGameFlag",
+      title: "ゲームフラグを設定する",
+      memo: "",
+      autoAdvance: false,
+      flagKey: "phase",
+      flagValue: "day",
+    });
+    expect(parsed.flagKeyOptions).toEqual([]);
+    expect(parsed.flagValueOptions).toEqual([]);
+  });
 });
 
 describe("SetGameFlagEntry.summary", () => {

--- a/frontend/src/flow/registry/SetGameFlag.tsx
+++ b/frontend/src/flow/registry/SetGameFlag.tsx
@@ -7,33 +7,138 @@ import { collectFlagKeyOptions, collectFlagValueOptions } from "../resources";
 import { SetGameFlagStepSchema, type SetGameFlagStep } from "../schema";
 import { defineStep, type DetailPanelProps } from "./types";
 
-const SetGameFlagDetailPanel = ({ step, onChange }: DetailPanelProps<SetGameFlagStep>) => {
+const ChoiceSelect = ({
+  value,
+  choices,
+  onChange,
+}: {
+  value: string;
+  choices: string[];
+  onChange: (value: string) => void;
+}) => (
+  <select
+    className="select w-full"
+    value={value}
+    onChange={(event) => onChange(event.target.value)}
+  >
+    {!choices.includes(value) && (
+      <option value={value}>{value === "" ? "選択してください" : value}</option>
+    )}
+    {choices.map((choice) => (
+      <option key={choice} value={choice}>
+        {choice}
+      </option>
+    ))}
+  </select>
+);
+
+const OptionListEditor = ({
+  options,
+  onChange,
+}: {
+  options: string[];
+  onChange: (options: string[]) => void;
+}) => (
+  <div className="flex flex-col gap-2">
+    {options.map((option, index) => (
+      // eslint-disable-next-line react/no-array-index-key -- 行 id を持たない素の文字列配列
+      <div key={index} className="flex items-center gap-2">
+        <input
+          type="text"
+          className="input input-sm w-full"
+          value={option}
+          onChange={(event) =>
+            onChange(options.map((v, i) => (i === index ? event.target.value : v)))
+          }
+          placeholder="候補を入力"
+        />
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          onClick={() => onChange(options.filter((_, i) => i !== index))}
+        >
+          削除
+        </button>
+      </div>
+    ))}
+    <button
+      type="button"
+      className="btn btn-ghost btn-sm self-start"
+      onClick={() => onChange([...options, ""])}
+    >
+      選択肢を追加
+    </button>
+  </div>
+);
+
+const SetGameFlagDetailPanel = ({ step, onChange, mode }: DetailPanelProps<SetGameFlagStep>) => {
   const resources = useTemplateResources(step.id);
   const keyOptions = useMemo(() => collectFlagKeyOptions(resources), [resources]);
   const valueOptions = useMemo(
     () => collectFlagValueOptions(resources, step.flagKey),
     [resources, step.flagKey],
   );
+  const isExecute = mode === "execute";
+  const keyChoices = step.flagKeyOptions.filter((option) => option.trim() !== "");
+  const valueChoices = step.flagValueOptions.filter((option) => option.trim() !== "");
 
   return (
     <div className="flex flex-col gap-3">
       <fieldset className="fieldset">
         <legend className="fieldset-legend">フラグ名</legend>
-        <DatalistInput
-          value={step.flagKey}
-          onChange={(flagKey) => onChange({ flagKey })}
-          options={keyOptions}
-          placeholder="例: アイテム入手, イベント発生済み"
-        />
+        {isExecute && keyChoices.length > 0 ? (
+          <ChoiceSelect
+            value={step.flagKey}
+            choices={keyChoices}
+            onChange={(flagKey) => onChange({ flagKey })}
+          />
+        ) : (
+          <DatalistInput
+            value={step.flagKey}
+            onChange={(flagKey) => onChange({ flagKey })}
+            options={keyOptions}
+            placeholder="例: アイテム入手, イベント発生済み"
+          />
+        )}
+        {!isExecute && (
+          <>
+            <div className="label">
+              <span className="label-text text-xs">実行時の選択肢 (空なら自由入力)</span>
+            </div>
+            <OptionListEditor
+              options={step.flagKeyOptions}
+              onChange={(flagKeyOptions) => onChange({ flagKeyOptions })}
+            />
+          </>
+        )}
       </fieldset>
       <fieldset className="fieldset">
         <legend className="fieldset-legend">値</legend>
-        <DatalistInput
-          value={step.flagValue}
-          onChange={(flagValue) => onChange({ flagValue })}
-          options={valueOptions}
-          placeholder="例: 1, アイテム名"
-        />
+        {isExecute && valueChoices.length > 0 ? (
+          <ChoiceSelect
+            value={step.flagValue}
+            choices={valueChoices}
+            onChange={(flagValue) => onChange({ flagValue })}
+          />
+        ) : (
+          <DatalistInput
+            value={step.flagValue}
+            onChange={(flagValue) => onChange({ flagValue })}
+            options={valueOptions}
+            placeholder="例: 1, アイテム名"
+          />
+        )}
+        {!isExecute && (
+          <>
+            <div className="label">
+              <span className="label-text text-xs">実行時の選択肢 (空なら自由入力)</span>
+            </div>
+            <OptionListEditor
+              options={step.flagValueOptions}
+              onChange={(flagValueOptions) => onChange({ flagValueOptions })}
+            />
+          </>
+        )}
       </fieldset>
     </div>
   );
@@ -50,6 +155,8 @@ export const SetGameFlagEntry = defineStep<SetGameFlagStep>({
     autoAdvance: false,
     flagKey: "",
     flagValue: "",
+    flagKeyOptions: [],
+    flagValueOptions: [],
   }),
   summary: (step) =>
     step.flagKey.trim() !== ""

--- a/frontend/src/flow/registry/execute.test.ts
+++ b/frontend/src/flow/registry/execute.test.ts
@@ -364,7 +364,16 @@ describe("SetGameFlag.execute", () => {
   test("フラグを書き込む", async () => {
     const { ctx, state } = createFakeContext();
     const result = await run(
-      { id: "s", type: "SetGameFlag", title: "", ...base, flagKey: "phase", flagValue: "day" },
+      {
+        id: "s",
+        type: "SetGameFlag",
+        title: "",
+        ...base,
+        flagKey: "phase",
+        flagValue: "day",
+        flagKeyOptions: [],
+        flagValueOptions: [],
+      },
       ctx,
     );
     expect(result.status).toBe("success");
@@ -374,7 +383,16 @@ describe("SetGameFlag.execute", () => {
   test("空キーは error", async () => {
     const { ctx } = createFakeContext();
     const result = await run(
-      { id: "s", type: "SetGameFlag", title: "", ...base, flagKey: "  ", flagValue: "x" },
+      {
+        id: "s",
+        type: "SetGameFlag",
+        title: "",
+        ...base,
+        flagKey: "  ",
+        flagValue: "x",
+        flagKeyOptions: [],
+        flagValueOptions: [],
+      },
       ctx,
     );
     expect(result.status).toBe("error");

--- a/frontend/src/flow/registry/types.ts
+++ b/frontend/src/flow/registry/types.ts
@@ -9,6 +9,8 @@ import type { Step } from "../schema";
 export interface DetailPanelProps<S extends Step = Step> {
   step: S;
   onChange: (patch: Partial<S>) => void;
+  // 省略時は "edit"。execute モードで UI を変えたいパネルだけが参照する。
+  mode?: "edit" | "execute";
 }
 
 // ステップタイプ 1 つ分の登録エントリ (docs: step-list-editor-architecture D1)。

--- a/frontend/src/flow/resources.test.ts
+++ b/frontend/src/flow/resources.test.ts
@@ -45,6 +45,8 @@ const flow: FlowData = {
           autoAdvance: false,
           flagKey: "phase",
           flagValue: "night",
+          flagKeyOptions: [],
+          flagValueOptions: [],
         },
         {
           id: "ct1",
@@ -184,6 +186,8 @@ const autoFlow: FlowData = {
                   autoAdvance: false,
                   flagKey: "innerFlag",
                   flagValue: "1",
+                  flagKeyOptions: [],
+                  flagValueOptions: [],
                 },
               ],
             },

--- a/frontend/src/flow/runner/RunnerDetailPanel.tsx
+++ b/frontend/src/flow/runner/RunnerDetailPanel.tsx
@@ -83,7 +83,7 @@ export const RunnerDetailPanel = ({ handlers }: { handlers: RunHandlers }) => {
             <div className="divider my-0" />
             {/* 実行済み action/branch は read-only。tool は常に操作可能。 */}
             <fieldset disabled={isExecuted && !isTool} className="contents">
-              <StepDetailPanel step={step} onChange={handleChange} />
+              <StepDetailPanel step={step} onChange={handleChange} mode="execute" />
             </fieldset>
           </>
         )}

--- a/frontend/src/flow/schema.ts
+++ b/frontend/src/flow/schema.ts
@@ -126,6 +126,9 @@ const SetGameFlagStepSchema = StepBaseSchema.extend({
   type: z.literal("SetGameFlag"),
   flagKey: z.string().trim(),
   flagValue: z.string().trim(),
+  // edit モードで用意する実行時の選択肢。空なら execute モードは自由入力のまま。
+  flagKeyOptions: z.array(z.string().trim()).default([]),
+  flagValueOptions: z.array(z.string().trim()).default([]),
 });
 
 // ---- ツール系ステップ (Discord 操作を伴わないフラグ操作 UI) ----

--- a/frontend/src/flow/store/editorStore.test.ts
+++ b/frontend/src/flow/store/editorStore.test.ts
@@ -87,6 +87,8 @@ describe("editorStore", () => {
                         autoAdvance: false,
                         flagKey: "k",
                         flagValue: "v",
+                        flagKeyOptions: [],
+                        flagValueOptions: [],
                       },
                     ],
                   },

--- a/frontend/src/flow/treeOps.test.ts
+++ b/frontend/src/flow/treeOps.test.ts
@@ -26,6 +26,8 @@ const leaf = (id: string, title = id): Step => ({
   autoAdvance: false,
   flagKey: "k",
   flagValue: "v",
+  flagKeyOptions: [],
+  flagValueOptions: [],
 });
 
 const branch = (id: string, arms: Array<{ id: string; label: string; steps: Step[] }>): Step => ({

--- a/frontend/test/stories/Flow/fixtures.ts
+++ b/frontend/test/stories/Flow/fixtures.ts
@@ -35,6 +35,8 @@ export const sampleFlow: FlowData = {
           autoAdvance: false,
           flagKey: "phase",
           flagValue: "day",
+          flagKeyOptions: [],
+          flagValueOptions: [],
         },
       ],
     },

--- a/frontend/test/stories/Flow/runnerFixtures.ts
+++ b/frontend/test/stories/Flow/runnerFixtures.ts
@@ -39,6 +39,8 @@ export const runnerFlow: FlowData = {
           autoAdvance: false,
           flagKey: "phase",
           flagValue: "day",
+          flagKeyOptions: [],
+          flagValueOptions: [],
         },
       ],
     },


### PR DESCRIPTION
## 概要

「ゲームフラグを設定する」ステップで、edit モードでフラグ名・値の選択肢を用意し、execute モードではその選択肢から select で選べるようにする。

#206 の datalist 補完はフロー内から自動収集した候補のみで、テンプレート作者が「実行時に GM へ提示する選択肢」を意図的に絞ることができなかった。選択肢を事前定義することでセッション中の入力ミスを防ぐ。

## 変更内容

- `SetGameFlagStepSchema` に `flagKeyOptions` / `flagValueOptions` を `.default([])` で追加
  - 旧 flowData はパース時に空配列で補完されるため Dexie migration 不要 (後方互換テストあり)
- `DetailPanelProps` に `mode?: "edit" | "execute"` を追加し、runner ホスト (`RunnerDetailPanel`) が `execute` を渡す
- SetGameFlag パネル:
  - **edit**: DatalistInput の下に「実行時の選択肢」エディタ (行追加/削除) をフラグ名・値それぞれに表示
  - **execute**: 選択肢があるフィールドは `<select>`、無ければ従来どおり datalist 付き自由入力。現在値が選択肢に無い場合も option として表示
- docs の registry インターフェース定義 (`mode` prop) を更新

## 検証

- `bun run --bun test` 581 pass / typecheck 0 errors / format / lint / knip 通過
- Codex レビュー: 指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)