### PR TITLE
ステップ複製機能を追加 (StepRow に ⧉ ボタン)

### DIFF
--- a/frontend/src/flow/components/StepList.tsx
+++ b/frontend/src/flow/components/StepList.tsx
@@ -58,6 +58,7 @@ interface StepRowProps {
 const StepRow = memo(
   ({ step, container, index }: StepRowProps) => {
     const selectStep = useEditorStore((state) => state.selectStep);
+    const duplicateStep = useEditorStore((state) => state.duplicateStep);
     const removeStep = useEditorStore((state) => state.removeStep);
     const selectedStepId = useEditorStore((state) => state.selectedStepId);
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -87,6 +88,17 @@ const StepRow = memo(
             ⠿
           </button>
           <StepRowContent step={step} />
+          <button
+            type="button"
+            className="btn btn-ghost btn-xs"
+            aria-label="ステップを複製"
+            onClick={(event) => {
+              event.stopPropagation();
+              duplicateStep(step.id);
+            }}
+          >
+            ⧉
+          </button>
           <button
             type="button"
             className="btn btn-ghost btn-xs"

--- a/frontend/src/flow/store/editorStore.test.ts
+++ b/frontend/src/flow/store/editorStore.test.ts
@@ -44,6 +44,29 @@ describe("editorStore", () => {
     expect(useEditorStore.getState().flowData.sections[0]?.steps[0]?.title).toBe("更新後");
   });
 
+  test("duplicateStep は複製を直後に挿入して選択する", () => {
+    useEditorStore
+      .getState()
+      .addStep("SetGameFlag", { container: sectionContainer("s1"), index: 0 });
+    const originalId = useEditorStore.getState().selectedStepId ?? "";
+    useEditorStore.getState().updateStep(originalId, { title: "元" });
+    useEditorStore.getState().duplicateStep(originalId);
+    const state = useEditorStore.getState();
+    const steps = state.flowData.sections[0]?.steps ?? [];
+    expect(steps).toHaveLength(2);
+    expect(steps[0]?.id).toBe(originalId);
+    expect(steps[1]?.id).not.toBe(originalId);
+    expect(steps[1]?.title).toBe("元");
+    expect(state.selectedStepId).toBe(steps[1]?.id ?? "");
+  });
+
+  test("duplicateStep は存在しない id を無視する", () => {
+    useEditorStore.getState().duplicateStep("zzz");
+    const state = useEditorStore.getState();
+    expect(state.flowData.sections[0]?.steps).toHaveLength(0);
+    expect(state.selectedStepId).toBeNull();
+  });
+
   test("removeStep は選択を解除する", () => {
     useEditorStore
       .getState()

--- a/frontend/src/flow/store/editorStore.ts
+++ b/frontend/src/flow/store/editorStore.ts
@@ -29,6 +29,7 @@ interface EditorActions {
   // union 不変条件を破る事故を型レベルで防ぐ。
   updateStep: (id: string, patch: Omit<Partial<Step>, "type">) => void;
   addStep: (type: Step["type"], at: StepLocation) => void;
+  duplicateStep: (id: string) => void;
   removeStep: (id: string) => void;
   moveStep: (id: string, to: StepLocation) => void;
   // ドラッグキャンセル時などに、以前の immutable スナップショットへ丸ごと差し戻す。
@@ -72,6 +73,12 @@ export const useEditorStore = create<EditorStore>()((set) => ({
       selectedStepId: step.id,
     }));
   },
+
+  duplicateStep: (id) =>
+    set((state) => {
+      const { flowData, newStep } = treeOps.duplicateStep(state.flowData, id);
+      return newStep === undefined ? {} : { flowData, selectedStepId: newStep.id };
+    }),
 
   removeStep: (id) =>
     set((state) => {

--- a/frontend/src/flow/treeOps.test.ts
+++ b/frontend/src/flow/treeOps.test.ts
@@ -6,6 +6,7 @@ import {
   clearDescendantExecution,
   collectDescendantStepIds,
   collectSteps,
+  duplicateStep,
   findSection,
   findStep,
   insertSection,
@@ -210,6 +211,54 @@ describe("removeStep", () => {
   test("存在しない id は no-op", () => {
     const flow = makeFlow();
     expect(removeStep(flow, "zzz")).toBe(flow);
+  });
+});
+
+describe("duplicateStep", () => {
+  test("元の直後に新 id で挿入し、内容は同じ", () => {
+    const { flowData, newStep } = duplicateStep(makeFlow(), "a");
+    expect(newStep).toBeDefined();
+    expect(stepIds(flowData, "s1")).toEqual(["a", newStep?.id ?? "", "b"]);
+    expect(newStep?.id).not.toBe("a");
+    expect(newStep?.title).toBe("a");
+    expect(newStep?.type).toBe("SetGameFlag");
+  });
+
+  test("分岐枝の中のステップも直後に複製できる", () => {
+    const { flowData, newStep } = duplicateStep(makeFlow(), "c");
+    expect(armIds(flowData, "arm1")).toEqual(["c", newStep?.id ?? ""]);
+  });
+
+  test("Branch は枝と入れ子ステップの id もすべて採番し直す", () => {
+    const { flowData, newStep } = duplicateStep(makeFlow(), "br");
+    if (newStep?.type !== "Branch") throw new Error("Branch を複製したはず");
+    expect(newStep.branches.map((arm) => arm.id)).not.toContain("arm1");
+    expect(newStep.branches.map((arm) => arm.id)).not.toContain("arm2");
+    const allIds = collectSteps(flowData).map((step) => step.id);
+    expect(new Set(allIds).size).toBe(allIds.length); // ツリー全体で id 重複なし
+    expect(newStep.branches[0]?.steps[0]?.title).toBe("c"); // 内容は保たれる
+  });
+
+  test("実行痕跡 (executedAt / executedBranchIds) は消える", () => {
+    const flow = makeFlow();
+    const br = findStep(flow, "br");
+    if (br?.type !== "Branch") throw new Error("unreachable");
+    br.executedAt = new Date("2026-01-01T00:00:00Z");
+    br.executedBranchIds = ["arm1"];
+    const armStep = br.branches[0]?.steps[0];
+    if (armStep !== undefined) armStep.executedAt = new Date("2026-01-01T00:00:00Z");
+    const { newStep } = duplicateStep(flow, "br");
+    if (newStep?.type !== "Branch") throw new Error("unreachable");
+    expect(newStep.executedAt).toBeUndefined();
+    expect(newStep.executedBranchIds).toBeUndefined();
+    expect(newStep.branches[0]?.steps[0]?.executedAt).toBeUndefined();
+  });
+
+  test("存在しない id は no-op", () => {
+    const flow = makeFlow();
+    const { flowData, newStep } = duplicateStep(flow, "zzz");
+    expect(flowData).toBe(flow);
+    expect(newStep).toBeUndefined();
   });
 });
 

--- a/frontend/src/flow/treeOps.ts
+++ b/frontend/src/flow/treeOps.ts
@@ -2,6 +2,8 @@ import { produce } from "immer";
 
 import type { FlowData, Step } from "./schema";
 
+import { generateId } from "./ids";
+
 // FlowData のツリー (Section[] > Step[]、Branch は branches[].steps に再帰) を
 // 純粋に変換するヘルパ群。**ツリーが再帰的であることを知るのはこのファイルだけ**で、
 // store / コンポーネントは名前付きヘルパを呼ぶだけにする (docs: step-list-editor-architecture D4)。
@@ -146,6 +148,35 @@ export const removeStep = (flow: FlowData, id: string): FlowData =>
     const located = locateStep(draft as FlowData, id);
     if (located !== undefined) located.parentSteps.splice(located.index, 1);
   });
+
+// 複製自身に加え、Branch の枝 (arm) と入れ子ステップの id もすべて採番し直す。
+// id が重複すると locateStep の検索や dnd-kit の sortable id が最初の 1 件しか
+// 指せなくなるため。実行痕跡 (executedAt / executedBranchIds) も一緒に消す。
+const reassignIds = (step: Step): void => {
+  step.id = generateId();
+  step.executedAt = undefined;
+  if (step.type !== "Branch") return;
+  step.executedBranchIds = undefined;
+  for (const arm of step.branches) {
+    arm.id = generateId();
+    for (const child of arm.steps) reassignIds(child);
+  }
+};
+
+export const duplicateStep = (
+  flow: FlowData,
+  id: string,
+): { flowData: FlowData; newStep: Step | undefined } => {
+  const located = locateStep(flow, id);
+  if (located === undefined) return { flowData: flow, newStep: undefined };
+  const newStep = structuredClone(located.step);
+  reassignIds(newStep);
+  const flowData = produce(flow, (draft) => {
+    const draftLocated = locateStep(draft as FlowData, id);
+    draftLocated?.parentSteps.splice(draftLocated.index + 1, 0, newStep);
+  });
+  return { flowData, newStep };
+};
 
 // dnd-kit の arrayMove と同じ意味論: 対象を取り除いた後の配列に to.index で挿入する。
 export const moveStep = (flow: FlowData, id: string, to: StepLocation): FlowData =>


### PR DESCRIPTION
## 概要

テンプレート編集画面のステップリストに複製ボタン (⧉) を追加する。

- 複製は元ステップの**直後**に挿入し、選択状態にする (タイトルはそのまま)
- **Branch** は枝 (arm) と入れ子ステップを含め deep copy し、id をすべて再採番 (id 重複は `locateStep` の検索や dnd-kit の sortable id を壊すため)
- 実行痕跡 (`executedAt` / `executedBranchIds`) はリセット

## 変更

- `flow/treeOps.ts` — `duplicateStep(flow, id)` を追加 (D4 に従い再帰はここに閉じる)
- `flow/store/editorStore.ts` — `duplicateStep(id)` アクション
- `flow/components/StepList.tsx` — StepRow の ✕ の隣に ⧉ ボタン (Branch のネスト行にも自動で付く)

## テスト

- treeOps: 直後挿入 / 枝内複製 / ネスト id のツリー全体一意性 / 実行痕跡リセット / 存在しない id の no-op
- editorStore: 複製後の選択 / 存在しない id の無視

test 588 pass · typecheck · format · lint · knip すべて通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)