### PR TITLE
chore(deps): upgrade @cloudflare/workers-types 4→5

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20251212.0",
+    "@cloudflare/workers-types": "5.20260808.1",
     "@types/bun": "1.3.13",
     "typescript": "6.0.3"
   }

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "zod": "4.4.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20251212.0",
+        "@cloudflare/workers-types": "5.20260808.1",
         "@types/bun": "1.3.13",
         "typescript": "6.0.3",
       },
@@ -136,7 +136,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260801.1", "", { "os": "win32", "cpu": "x64" }, "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20251212.0", "", {}, "sha512-RrvbKQli+zkDSLtqmsQetHoc38Zi6VWajb0E79w3lGDbJ0Qq1T4HavAm5jIQ+1R6CJxpWO6t41aefRakj+ciaw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260808.1", "", {}, "sha512-DN7G9SMyeOq031YhQexoExFAK78ms74cFiFF1teDlTK4+LjHgIc5Z8VbvXQtcCIP//o38btxzxW0b9MGPA83CA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 


### PR DESCRIPTION
## Package
`@cloudflare/workers-types` (backend devDependency)

## Before → After
`4.20251212.0` → `5.20260808.1`

## Summary

Major version bump. Researched the v5 release ([Cloudflare changelog](https://developers.cloudflare.com/changelog/post/2026-07-03-workers-types-v5/)): the only breaking change is removal of the dated subpath entrypoints (e.g. `@cloudflare/workers-types/2022-11-30`, `@cloudflare/workers-types/2023-03-01`). Cloudflare now recommends `wrangler types` for compat-date-locked types instead.

This repo's `backend/tsconfig.json` only references the bare package name (`"types": ["@cloudflare/workers-types", "bun"]`) — no dated entrypoint imports anywhere in `backend/` or `frontend/` — so the breaking change doesn't apply here. No code changes were needed.

## Verification
- `bun run --bun typecheck` — 0 errors (backend + frontend)
- `bun run --bun test` — 48 backend + 588 frontend tests pass
- `bun run --bun format` — clean
- `bun run --bun lint` — clean
- `bun run knip` — clean (pre-existing config hint only, unrelated)
- `bun run --bun build` — succeeds

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01KRGFemRkXTTUjbh4ysTR7G)_