### PR TITLE
chore(deps): upgrade oxlint 1.32.0→1.77.0, oxfmt 0.17.0→0.62.0

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -1,7 +1,9 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  // ignorePatterns are rooted at this config file's directory (oxfmt >=0.59),
+  // so paths must be repo-root-relative, not per-workspace-relative.
   "ignorePatterns": [
-    "src/routeTree.gen.ts"
+    "frontend/src/routeTree.gen.ts"
   ],
   // Enable import sorting with default settings
   "experimentalSortImports": {}

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -1,5 +1,6 @@
-import { DiscordAPIError, RateLimitError } from "@discordjs/rest";
 import { describe, test, expect, spyOn, beforeEach, afterEach } from "bun:test";
+
+import { DiscordAPIError, RateLimitError } from "@discordjs/rest";
 
 import * as discord from "./discord";
 import app from "./index";

--- a/backend/src/schemas.test.ts
+++ b/backend/src/schemas.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "bun:test";
+
 import { ZodError } from "zod";
 
 import {

--- a/bun.lock
+++ b/bun.lock
@@ -8,8 +8,8 @@
         "@types/node": "26.2.0",
         "knip": "6.11.0",
         "npm-check-updates": "23.0.2",
-        "oxfmt": "0.17.0",
-        "oxlint": "1.32.0",
+        "oxfmt": "0.62.0",
+        "oxlint": "1.77.0",
         "oxlint-tsgolint": "0.23.0",
         "typescript": "6.0.3",
         "wrangler": "4.120.0",
@@ -382,21 +382,43 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.24.2", "", { "os": "win32", "cpu": "x64" }, "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw=="],
 
-    "@oxfmt/darwin-arm64": ["@oxfmt/darwin-arm64@0.17.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-OMv0tOb+xiwSZKjYbM6TwMSP5QwFJlBGQmEsk98QJ30sHhdyC//0UvGKuR0KZuzZW4E0+k0rHDmos1Z5DmBEkA=="],
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.62.0", "", { "os": "android", "cpu": "arm" }, "sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw=="],
 
-    "@oxfmt/darwin-x64": ["@oxfmt/darwin-x64@0.17.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-trzidyzryKIdL/cLCYU9IwprgJegVBUrz1rqzOMe5is+qdgH/RxTCvhYUNFzxRHpil3g4QUYd2Ja831tc5Nehg=="],
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.62.0", "", { "os": "android", "cpu": "arm64" }, "sha512-WC3YQ7uS/KtDrjmqwBviwFKe9qeoi+eXx8aX1z/ffG23Md75myjrJaQqTuJvdOLPoa4EYTjDWH0dHXfwulCVog=="],
 
-    "@oxfmt/linux-arm64-gnu": ["@oxfmt/linux-arm64-gnu@0.17.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-KlwzidgvHznbUaaglZT1goTS30osTV553pfbKve9B1PyTDkluNDfm/polOaf3SVLN7wL/NNLFZRMupvJ1eJXAw=="],
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.62.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GM8Yf3LjjaR1I8PD0SfeoIlwhsh9GvSF+cQ8sf624Yxnjsyumn95aFzYfKJVefblfDIiOAnZ7QVm2sa21Er/0Q=="],
 
-    "@oxfmt/linux-arm64-musl": ["@oxfmt/linux-arm64-musl@0.17.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-+tbYJTocF4BNLaQQbc/xrBWTNgiU6zmYeF4NvRDxuuQjDOnmUZPn0EED3PZBRJyg4/YllhplHDo8x+gfcb9G3A=="],
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.62.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-d5THp7F8bCxLqNogEXDORRsQD6dosf3EyFtnXfBer6v+8tGdcWIjoDX9WaXrrF/26zOmL8qHpPTKCEvpBDmZkQ=="],
 
-    "@oxfmt/linux-x64-gnu": ["@oxfmt/linux-x64-gnu@0.17.0", "", { "os": "linux", "cpu": "x64" }, "sha512-pEmv7zJIw2HpnA4Tn1xrfJNGi2wOH2+usT14Pkvf/c5DdB+pOir6k/5jzfe70+V3nEtmtV9Lm+spndN/y6+X7A=="],
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.62.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1DnrtXGZooOZ0fHgAXZUaDQzBVh1CM2MNW4oBXyQ2aWKvCHjyljvT9fgBkOM0fEOb96X5eqtcfJ0YUVt9jj66g=="],
 
-    "@oxfmt/linux-x64-musl": ["@oxfmt/linux-x64-musl@0.17.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+DrFSCZWyFdtEAWR5xIBTV8GX0RA9iB+y7ZlJPRAXrNG8TdBY9vc7/MIGolIgrkMPK4mGMn07YG/qEyPY+iKaw=="],
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-4pQDHOYRH+Huqe0StIaWyvk2CVl/aTaqSrbZpA3/pLS2xH24ME7lBgYprhQF2fRkHBzhGGGKliwxFsDdHwx59g=="],
 
-    "@oxfmt/win32-arm64": ["@oxfmt/win32-arm64@0.17.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-FoUZRR7mVpTYIaY/qz2BYwzqMnL+HsUxmMWAIy6nl29UEkDgxNygULJ4rIGY4/Axne41fhtldLrSGBOpwNm3jA=="],
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-X0jAaZJFMCVKhB6YyWVTQ/wN2DLsBcZKSMqTS76bF6riT+XZdtg2FPEdjDvdVbunO9cG+tWiVaEs4Zs38lxYog=="],
 
-    "@oxfmt/win32-x64": ["@oxfmt/win32-x64@0.17.0", "", { "os": "win32", "cpu": "x64" }, "sha512-fBIcUpHmCwf3leWlo0cYwLb9Pd2mzxQlZYJX9dD9nylPvsxOnsy9fmsaflpj34O0JbQJN3Y0SRkoaCcHHlxFww=="],
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-682Z8T5s8T5ATArYtsejKvbIfd8LEAXyyDkKkoZVq8HND7Vx8TYLlrDjDSeYfodMeVwHOgkj13lJYR8cj6vUSg=="],
+
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew=="],
+
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.62.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw=="],
+
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA=="],
+
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A=="],
+
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.62.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A=="],
+
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w=="],
+
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw=="],
+
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.62.0", "", { "os": "none", "cpu": "arm64" }, "sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA=="],
+
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.62.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-OfwuhkcjDlqC4EgDojtiV9mzpLqeB9KqTOWPOjLEYBVdDCVSxqW3qzp/xcIxsbtI0UgGCnKvAqYKyY25kf5JZw=="],
+
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.62.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw=="],
+
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ=="],
 
     "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.23.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw=="],
 
@@ -410,21 +432,43 @@
 
     "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.23.0", "", { "os": "win32", "cpu": "x64" }, "sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ=="],
 
-    "@oxlint/darwin-arm64": ["@oxlint/darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yrqPmZYu5Qb+49h0P5EXVIq8VxYkDDM6ZQrWzlh16+UGFcD8HOXs4oF3g9RyfaoAbShLCXooSQsM/Ifwx8E/eQ=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.77.0", "", { "os": "android", "cpu": "arm" }, "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ=="],
 
-    "@oxlint/darwin-x64": ["@oxlint/darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-pQRZrJG/2nAKc3IuocFbaFFbTDlQsjz2WfivRsMn0hw65EEsSuM84WMFMiAfLpTGyTICeUtHZLHlrM5lzVr36A=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.77.0", "", { "os": "android", "cpu": "arm64" }, "sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA=="],
 
-    "@oxlint/linux-arm64-gnu": ["@oxlint/linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tyomSmU2DzwcTmbaWFmStHgVfRmJDDvqcIvcw4fRB1YlL2Qg/XaM4NJ0m2bdTap38gxD5FSxSgCo0DkQ8GTolg=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.77.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA=="],
 
-    "@oxlint/linux-arm64-musl": ["@oxlint/linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0W46dRMaf71OGE4+Rd+GHfS1uF/UODl5Mef6871pMhN7opPGfTI2fKJxh9VzRhXeSYXW/Z1EuCq9yCfmIJq+5Q=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.77.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA=="],
 
-    "@oxlint/linux-x64-gnu": ["@oxlint/linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5+6myVCBOMvM62rDB9T3CARXUvIwhGqte6E+HoKRwYaqsxGUZ4bh3pItSgSFwHjLGPrvADS11qJUkk39eQQBzQ=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.77.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg=="],
 
-    "@oxlint/linux-x64-musl": ["@oxlint/linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-qwQlwYYgVIC6ScjpUwiKKNyVdUlJckrfwPVpIjC9mvglIQeIjKuuyaDxUZWIOc/rEzeCV/tW6tcbehLkfEzqsw=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.77.0", "", { "os": "linux", "cpu": "arm" }, "sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA=="],
 
-    "@oxlint/win32-arm64": ["@oxlint/win32-arm64@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-7qYZF9CiXGtdv8Z/fBkgB5idD2Zokht67I5DKWH0fZS/2R232sDqW2JpWVkXltk0+9yFvmvJ0ouJgQRl9M3S2g=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.77.0", "", { "os": "linux", "cpu": "arm" }, "sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ=="],
 
-    "@oxlint/win32-x64": ["@oxlint/win32-x64@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-XW1xqCj34MEGJlHteqasTZ/LmBrwYIgluhNW0aP+XWkn90+stKAq3W/40dvJKbMK9F7o09LPCuMVtUW7FIUuiA=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.77.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.77.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.77.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.77.0", "", { "os": "linux", "cpu": "none" }, "sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.77.0", "", { "os": "linux", "cpu": "none" }, "sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.77.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.77.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.77.0", "", { "os": "linux", "cpu": "x64" }, "sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.77.0", "", { "os": "none", "cpu": "arm64" }, "sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.77.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.77.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.77.0", "", { "os": "win32", "cpu": "x64" }, "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw=="],
 
     "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
 
@@ -938,9 +982,9 @@
 
     "oxc-resolver": ["oxc-resolver@11.24.2", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.24.2", "@oxc-resolver/binding-android-arm64": "11.24.2", "@oxc-resolver/binding-darwin-arm64": "11.24.2", "@oxc-resolver/binding-darwin-x64": "11.24.2", "@oxc-resolver/binding-freebsd-x64": "11.24.2", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2", "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2", "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2", "@oxc-resolver/binding-linux-arm64-musl": "11.24.2", "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2", "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2", "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2", "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2", "@oxc-resolver/binding-linux-x64-gnu": "11.24.2", "@oxc-resolver/binding-linux-x64-musl": "11.24.2", "@oxc-resolver/binding-openharmony-arm64": "11.24.2", "@oxc-resolver/binding-wasm32-wasi": "11.24.2", "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2", "@oxc-resolver/binding-win32-x64-msvc": "11.24.2" } }, "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw=="],
 
-    "oxfmt": ["oxfmt@0.17.0", "", { "optionalDependencies": { "@oxfmt/darwin-arm64": "0.17.0", "@oxfmt/darwin-x64": "0.17.0", "@oxfmt/linux-arm64-gnu": "0.17.0", "@oxfmt/linux-arm64-musl": "0.17.0", "@oxfmt/linux-x64-gnu": "0.17.0", "@oxfmt/linux-x64-musl": "0.17.0", "@oxfmt/win32-arm64": "0.17.0", "@oxfmt/win32-x64": "0.17.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-12Rmq2ub61rUZ3Pqnsvmo99rRQ6hQJwQsjnFnbvXYLMrlIsWT6SFVsrjAkBBrkXXSHv8ePIpKQ0nZph5KDrOqw=="],
+    "oxfmt": ["oxfmt@0.62.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.62.0", "@oxfmt/binding-android-arm64": "0.62.0", "@oxfmt/binding-darwin-arm64": "0.62.0", "@oxfmt/binding-darwin-x64": "0.62.0", "@oxfmt/binding-freebsd-x64": "0.62.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.62.0", "@oxfmt/binding-linux-arm-musleabihf": "0.62.0", "@oxfmt/binding-linux-arm64-gnu": "0.62.0", "@oxfmt/binding-linux-arm64-musl": "0.62.0", "@oxfmt/binding-linux-ppc64-gnu": "0.62.0", "@oxfmt/binding-linux-riscv64-gnu": "0.62.0", "@oxfmt/binding-linux-riscv64-musl": "0.62.0", "@oxfmt/binding-linux-s390x-gnu": "0.62.0", "@oxfmt/binding-linux-x64-gnu": "0.62.0", "@oxfmt/binding-linux-x64-musl": "0.62.0", "@oxfmt/binding-openharmony-arm64": "0.62.0", "@oxfmt/binding-win32-arm64-msvc": "0.62.0", "@oxfmt/binding-win32-ia32-msvc": "0.62.0", "@oxfmt/binding-win32-x64-msvc": "0.62.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ=="],
 
-    "oxlint": ["oxlint@1.32.0", "", { "optionalDependencies": { "@oxlint/darwin-arm64": "1.32.0", "@oxlint/darwin-x64": "1.32.0", "@oxlint/linux-arm64-gnu": "1.32.0", "@oxlint/linux-arm64-musl": "1.32.0", "@oxlint/linux-x64-gnu": "1.32.0", "@oxlint/linux-x64-musl": "1.32.0", "@oxlint/win32-arm64": "1.32.0", "@oxlint/win32-x64": "1.32.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.8.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint", "oxc_language_server": "bin/oxc_language_server" } }, "sha512-HYDQCga7flsdyLMUIxTgSnEx5KBxpP9VINB8NgO+UjV80xBiTQXyVsvjtneMT3ZBLMbL0SlG/Dm03XQAsEshMA=="],
+    "oxlint": ["oxlint@1.77.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.77.0", "@oxlint/binding-android-arm64": "1.77.0", "@oxlint/binding-darwin-arm64": "1.77.0", "@oxlint/binding-darwin-x64": "1.77.0", "@oxlint/binding-freebsd-x64": "1.77.0", "@oxlint/binding-linux-arm-gnueabihf": "1.77.0", "@oxlint/binding-linux-arm-musleabihf": "1.77.0", "@oxlint/binding-linux-arm64-gnu": "1.77.0", "@oxlint/binding-linux-arm64-musl": "1.77.0", "@oxlint/binding-linux-ppc64-gnu": "1.77.0", "@oxlint/binding-linux-riscv64-gnu": "1.77.0", "@oxlint/binding-linux-riscv64-musl": "1.77.0", "@oxlint/binding-linux-s390x-gnu": "1.77.0", "@oxlint/binding-linux-x64-gnu": "1.77.0", "@oxlint/binding-linux-x64-musl": "1.77.0", "@oxlint/binding-openharmony-arm64": "1.77.0", "@oxlint/binding-win32-arm64-msvc": "1.77.0", "@oxlint/binding-win32-ia32-msvc": "1.77.0", "@oxlint/binding-win32-x64-msvc": "1.77.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg=="],
 
     "oxlint-tsgolint": ["oxlint-tsgolint@0.23.0", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.23.0", "@oxlint-tsgolint/darwin-x64": "0.23.0", "@oxlint-tsgolint/linux-arm64": "0.23.0", "@oxlint-tsgolint/linux-x64": "0.23.0", "@oxlint-tsgolint/win32-arm64": "0.23.0", "@oxlint-tsgolint/win32-x64": "0.23.0" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA=="],
 
@@ -1053,6 +1097,8 @@
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
     "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 

--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -1,15 +1,13 @@
-import type z from "zod";
-
 import { useLiveQuery } from "dexie-react-hooks";
 import { type MouseEvent, useEffect, useState } from "react";
-
-import type { FlowData } from "@/flow/schema";
+import type z from "zod";
 
 import { ApiClient } from "@/api";
 import { db, type ReactFlowData } from "@/db";
 import { type GuildSchema } from "@/db";
 import { FileSystem, convertFilePathsInReactFlowData } from "@/fileSystem";
 import { convertFilePathsInFlowData } from "@/flow/filePaths";
+import type { FlowData } from "@/flow/schema";
 import { useToast } from "@/toast/ToastProvider";
 
 interface Props {

--- a/frontend/src/components/Node/base/base-node.tsx
+++ b/frontend/src/components/Node/base/base-node.tsx
@@ -1,9 +1,8 @@
+import { Handle, type HandleProps } from "@xyflow/react";
+import { clsx, type ClassValue } from "clsx";
 // https://reactflow.dev/ui/components/base-node
 // Copyright (c) 2019-2025 webkid GmbH
 import type { ComponentProps } from "react";
-
-import { Handle, type HandleProps } from "@xyflow/react";
-import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 import type { NodeWidth } from "./base-schema";

--- a/frontend/src/components/Node/nodes/CommentNode.tsx
+++ b/frontend/src/components/Node/nodes/CommentNode.tsx
@@ -1,5 +1,4 @@
 import type { Node, NodeProps } from "@xyflow/react";
-
 import { NodeResizer } from "@xyflow/react";
 import z from "zod";
 

--- a/frontend/src/components/Node/nodes/LabeledGroupNode.tsx
+++ b/frontend/src/components/Node/nodes/LabeledGroupNode.tsx
@@ -1,6 +1,5 @@
-import type { ComponentProps, ReactNode } from "react";
-
 import { type Node, type NodeProps, NodeResizer } from "@xyflow/react";
+import type { ComponentProps, ReactNode } from "react";
 import z from "zod";
 
 import { useTemplateEditorStore } from "@/stores/templateEditorStore";

--- a/frontend/src/components/Node/utils/DynamicValueInput.tsx
+++ b/frontend/src/components/Node/utils/DynamicValueInput.tsx
@@ -1,6 +1,5 @@
-import type { DynamicValue } from "./DynamicValue";
-
 import { useNodeExecutionOptional } from "../contexts";
+import type { DynamicValue } from "./DynamicValue";
 import { ResourceSelector } from "./ResourceSelector";
 
 type SupportedType = "literal" | "session.name" | "roleRef" | "channelRef" | "gameFlag";

--- a/frontend/src/components/Node/utils/collectResources.test.ts
+++ b/frontend/src/components/Node/utils/collectResources.test.ts
@@ -1,6 +1,6 @@
-import type { Edge } from "@xyflow/react";
-
 import { describe, expect, it } from "bun:test";
+
+import type { Edge } from "@xyflow/react";
 
 import type { FlowNode } from "@/stores/templateEditorStore";
 

--- a/frontend/src/components/Node/utils/evaluateCondition.test.ts
+++ b/frontend/src/components/Node/utils/evaluateCondition.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
 import type { RuleNode, ConditionNode, Branch } from "./evaluateCondition";
-
 import {
   evaluateRule,
   evaluateConditionNode,

--- a/frontend/src/components/SessionResourcePanel.tsx
+++ b/frontend/src/components/SessionResourcePanel.tsx
@@ -2,9 +2,8 @@ import { Panel } from "@xyflow/react";
 import { useLiveQuery } from "dexie-react-hooks";
 import { LuFlag, LuHash, LuMic, LuPanelRight, LuUsers, LuX } from "react-icons/lu";
 
-import type { ChannelData, GameFlags, RoleData } from "@/db/schemas";
-
 import { db, GameSession } from "@/db";
+import type { ChannelData, GameFlags, RoleData } from "@/db/schemas";
 
 interface SessionResourcePanelProps {
   sessionId: number;

--- a/frontend/src/components/TemplateEditor.tsx
+++ b/frontend/src/components/TemplateEditor.tsx
@@ -12,13 +12,13 @@ import {
   Panel,
   useReactFlow,
 } from "@xyflow/react";
+
 import "@xyflow/react/dist/style.css";
 import { useCallback, useEffect, useMemo, useState, useRef } from "react";
 
-import type { DiscordBotData } from "@/db";
-
 import { createNodeTypes, NodeExecutionContext, TemplateEditorContext } from "@/components/Node";
 import { SessionResourcePanel } from "@/components/SessionResourcePanel";
+import type { DiscordBotData } from "@/db";
 import { useFileExistenceValidation } from "@/hooks/useFileExistenceValidation";
 import { useTemplateEditorStore, type FlowNode } from "@/stores/templateEditorStore";
 

--- a/frontend/src/db/database.ts
+++ b/frontend/src/db/database.ts
@@ -8,6 +8,7 @@ if (typeof process !== "undefined" && process.env.NODE_ENV === "test") {
   Dexie.dependencies.IDBKeyRange = IDBKeyRange;
 }
 
+import { applyFlowDataMigration } from "../flow/migrate";
 import type {
   CategoryData,
   ChannelData,
@@ -17,8 +18,6 @@ import type {
   RoleData,
   TemplateData,
 } from "./schemas";
-
-import { applyFlowDataMigration } from "../flow/migrate";
 
 const ReactFlowNodeSchema = z.looseObject({
   type: z.string().optional(),

--- a/frontend/src/db/flowDataMigration.test.ts
+++ b/frontend/src/db/flowDataMigration.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+
 import Dexie from "dexie";
 
 import { applyFlowDataMigration } from "@/flow/migrate";

--- a/frontend/src/db/models/GameSession.test.ts
+++ b/frontend/src/db/models/GameSession.test.ts
@@ -1,8 +1,7 @@
-import { createTestSession } from "#test/factories";
 import { describe, test, expect, spyOn } from "bun:test";
 
+import { createTestSession } from "#test/factories";
 import type { FlowData } from "@/flow/schema";
-
 import { defaultFlowData } from "@/flow/schema";
 
 import { defaultReactFlowData } from "../schemas";

--- a/frontend/src/db/models/GameSession.ts
+++ b/frontend/src/db/models/GameSession.ts
@@ -1,11 +1,9 @@
 import { Entity } from "dexie";
 
 import type { FlowData } from "@/flow/schema";
-
 import { FlowDataSchema, defaultFlowData } from "@/flow/schema";
 
 import type { DB } from "../database";
-
 import { db } from "../instance";
 import {
   GameFlagsSchema,

--- a/frontend/src/db/models/Template.test.ts
+++ b/frontend/src/db/models/Template.test.ts
@@ -1,7 +1,6 @@
 import { describe, test, expect, spyOn } from "bun:test";
 
 import type { FlowData } from "@/flow/schema";
-
 import { defaultFlowData } from "@/flow/schema";
 
 import { defaultReactFlowData } from "../schemas";

--- a/frontend/src/db/models/Template.ts
+++ b/frontend/src/db/models/Template.ts
@@ -1,12 +1,10 @@
 import { Entity } from "dexie";
 
-import type { FlowData } from "@/flow/schema";
-
 import { reactFlowToFlowData } from "@/flow/migrate";
+import type { FlowData } from "@/flow/schema";
 import { FlowDataSchema, defaultFlowData } from "@/flow/schema";
 
 import type { DB } from "../database";
-
 import { db } from "../instance";
 import {
   GameFlagsSchema,

--- a/frontend/src/fileSystem.test.ts
+++ b/frontend/src/fileSystem.test.ts
@@ -1,7 +1,6 @@
 import { describe, test, expect, beforeEach, mock } from "bun:test";
 
 import type { ReactFlowData } from "./db";
-
 import {
   FileSystem,
   collectFilePathsFromReactFlowData,

--- a/frontend/src/flow/components/AddStepMenu.tsx
+++ b/frontend/src/flow/components/AddStepMenu.tsx
@@ -1,11 +1,10 @@
 import { useMemo } from "react";
 
+import { getEntry, stepTypes } from "../registry";
 import type { StepRegistryEntry } from "../registry/types";
 import type { Step } from "../schema";
-import type { StepContainer } from "../treeOps";
-
-import { getEntry, stepTypes } from "../registry";
 import { useEditorStore } from "../store/editorStore";
+import type { StepContainer } from "../treeOps";
 
 interface MenuItem {
   type: Step["type"];

--- a/frontend/src/flow/components/ConditionTreeEditor.tsx
+++ b/frontend/src/flow/components/ConditionTreeEditor.tsx
@@ -1,5 +1,4 @@
 import type { ConditionNode, GroupNode, RuleNode } from "@/components/Node/utils/evaluateCondition";
-
 import { FlagValueSelector } from "@/components/Node/utils/FlagValueSelector";
 import { ResourceSelector } from "@/components/Node/utils/ResourceSelector";
 

--- a/frontend/src/flow/components/DetailPanel.tsx
+++ b/frontend/src/flow/components/DetailPanel.tsx
@@ -2,10 +2,9 @@ import { useMemo } from "react";
 
 import { TemplateResourcesOverrideProvider } from "@/components/Node/utils/useTemplateResources";
 
-import type { Step } from "../schema";
-
 import { getEntry } from "../registry";
 import { collectResourcesFromFlow } from "../resources";
+import type { Step } from "../schema";
 import { useEditorStore } from "../store/editorStore";
 import { findStep } from "../treeOps";
 

--- a/frontend/src/flow/components/MessageBlocksEditor.tsx
+++ b/frontend/src/flow/components/MessageBlocksEditor.tsx
@@ -1,7 +1,6 @@
-import type { z } from "zod";
-
 import { useRef, useState, type ChangeEvent, type DragEvent } from "react";
 import { LuDownload, LuUpload } from "react-icons/lu";
+import type { z } from "zod";
 
 import {
   type Attachment,

--- a/frontend/src/flow/components/SectionHeader.tsx
+++ b/frontend/src/flow/components/SectionHeader.tsx
@@ -1,8 +1,7 @@
 import type { DraggableAttributes, DraggableSyntheticListeners } from "@dnd-kit/core";
 
-import type { Section } from "../treeOps";
-
 import { useEditorStore } from "../store/editorStore";
+import type { Section } from "../treeOps";
 
 interface SectionHeaderProps {
   section: Section;

--- a/frontend/src/flow/components/StepList.tsx
+++ b/frontend/src/flow/components/StepList.tsx
@@ -4,12 +4,11 @@ import { CSS } from "@dnd-kit/utilities";
 import clsx from "clsx";
 import { memo } from "react";
 
-import type { Step } from "../schema";
-import type { StepContainer } from "../treeOps";
-
 import { getEntry } from "../registry";
 import { CATEGORY_CLASS, CATEGORY_LABEL } from "../registry/category";
+import type { Step } from "../schema";
 import { useEditorStore } from "../store/editorStore";
+import type { StepContainer } from "../treeOps";
 import { AddStepMenu } from "./AddStepMenu";
 import { type DragData, emptyContainerDropId, sameContainer } from "./dnd";
 

--- a/frontend/src/flow/components/StepListPanel.tsx
+++ b/frontend/src/flow/components/StepListPanel.tsx
@@ -17,9 +17,8 @@ import clsx from "clsx";
 import { useRef, useState } from "react";
 
 import type { FlowData } from "../schema";
-import type { Section } from "../treeOps";
-
 import { useEditorStore } from "../store/editorStore";
+import type { Section } from "../treeOps";
 import { findStep } from "../treeOps";
 import { AddStepMenu } from "./AddStepMenu";
 import { type DragData, dropLocation, getDragData, sameContainer } from "./dnd";

--- a/frontend/src/flow/components/dnd.test.ts
+++ b/frontend/src/flow/components/dnd.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { StepContainer } from "../treeOps";
-
 import { dropLocation, emptyContainerDropId, sameContainer } from "./dnd";
 
 const section = (sectionId: string): StepContainer => ({ kind: "section", sectionId });

--- a/frontend/src/flow/convert.ts
+++ b/frontend/src/flow/convert.ts
@@ -1,11 +1,9 @@
 import z from "zod";
 
 import type { ConditionNode } from "@/components/Node/utils/evaluateCondition";
-
 import { conditionToInfix } from "@/components/Node/utils/evaluateCondition";
 
 import type { FlowData, Step } from "./schema";
-
 import { FlowDataSchema, StepSchema } from "./schema";
 
 // reactFlowData (グラフ) → FlowData (ステップツリー) のベストエフォート変換器。

--- a/frontend/src/flow/engine/branch.test.ts
+++ b/frontend/src/flow/engine/branch.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, test } from "bun:test";
 import type { ConditionNode } from "@/components/Node/utils/evaluateCondition";
 
 import type { BranchArm, BranchStep } from "../schema";
-
 import { selectAutoArms } from "./branch";
 
 const rule = (flagKey: string, value: string): ConditionNode => ({

--- a/frontend/src/flow/engine/execute.test.ts
+++ b/frontend/src/flow/engine/execute.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import type { BranchStep, FlowData, Step } from "../schema";
-import type { StepRunner } from "./execute";
-import type { ExecuteResult } from "./types";
-
 import * as treeOps from "../treeOps";
+import type { StepRunner } from "./execute";
 import { runChain } from "./execute";
+import type { ExecuteResult } from "./types";
 
 const step = (id: string, overrides: Partial<Step> = {}): Step =>
   ({

--- a/frontend/src/flow/engine/execute.ts
+++ b/frontend/src/flow/engine/execute.ts
@@ -1,8 +1,7 @@
 import type { FlowData, Step } from "../schema";
-import type { ExecuteResult } from "./types";
-
 import { findStep } from "../treeOps";
 import { advanceCursor } from "./order";
+import type { ExecuteResult } from "./types";
 
 // engine は orchestration だけを持つ (docs: "The engine ... owns orchestration only")。
 // 1 ステップを走らせ、そのステップが autoAdvance なら次ステップへ連鎖する。

--- a/frontend/src/flow/engine/gateway.ts
+++ b/frontend/src/flow/engine/gateway.ts
@@ -1,6 +1,5 @@
-import type { DiscordBotData } from "@/db";
-
 import { ApiClient } from "@/api";
+import type { DiscordBotData } from "@/db";
 import { FileSystem } from "@/fileSystem";
 
 import type { DiscordGateway } from "./types";

--- a/frontend/src/flow/engine/order.test.ts
+++ b/frontend/src/flow/engine/order.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { BranchStep, FlowData, Step } from "../schema";
-
 import { advanceCursor, firstRunnableId, runnableSteps } from "./order";
 
 const step = (id: string, overrides: Partial<Step> = {}): Step =>

--- a/frontend/src/flow/filePaths.test.ts
+++ b/frontend/src/flow/filePaths.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
-import type { FlowData } from "./schema";
-
 import { convertFilePathsInFlowData } from "./filePaths";
+import type { FlowData } from "./schema";
 import { FlowDataSchema } from "./schema";
 
 const flow = (sections: unknown[]): FlowData => FlowDataSchema.parse({ version: 1, sections });

--- a/frontend/src/flow/migrate.test.ts
+++ b/frontend/src/flow/migrate.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, spyOn, test } from "bun:test";
 
-import type { FlowData } from "./schema";
-
 import { foldWarningsIntoFlowData, migrateRecordToFlowData, reactFlowToFlowData } from "./migrate";
+import type { FlowData } from "./schema";
 import { FlowDataSchema, defaultFlowData } from "./schema";
 
 // ---- フィクスチャ ----

--- a/frontend/src/flow/migrate.ts
+++ b/frontend/src/flow/migrate.ts
@@ -1,9 +1,8 @@
 import type { Transaction } from "dexie";
 
 import type { ConversionWarning } from "./convert";
-import type { FlowData, Step } from "./schema";
-
 import { convertReactFlowToFlowData } from "./convert";
+import type { FlowData, Step } from "./schema";
 import { FlowDataSchema, defaultFlowData } from "./schema";
 
 // reactFlowData → flowData の Dexie マイグレーション (issue #182 Phase 1)。

--- a/frontend/src/flow/registry/AddRoleToRoleMembers.test.ts
+++ b/frontend/src/flow/registry/AddRoleToRoleMembers.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { AddRoleToRoleMembersStep } from "../schema";
-
 import { AddRoleToRoleMembersEntry } from "./AddRoleToRoleMembers";
 
 const makeStep = (overrides: Partial<AddRoleToRoleMembersStep> = {}): AddRoleToRoleMembersStep => ({

--- a/frontend/src/flow/registry/ChangeChannelPermission.test.ts
+++ b/frontend/src/flow/registry/ChangeChannelPermission.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { ChangeChannelPermissionStep } from "../schema";
-
 import { ChangeChannelPermissionEntry } from "./ChangeChannelPermission";
 
 const makeStep = (

--- a/frontend/src/flow/registry/Counter.test.ts
+++ b/frontend/src/flow/registry/Counter.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { CounterStep } from "../schema";
-
 import { CounterEntry } from "./Counter";
 
 const makeStep = (overrides: Partial<CounterStep> = {}): CounterStep => ({

--- a/frontend/src/flow/registry/CreateCategory.test.ts
+++ b/frontend/src/flow/registry/CreateCategory.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { CreateCategoryStep } from "../schema";
-
 import { CreateCategoryEntry } from "./CreateCategory";
 
 const step = (overrides: Partial<CreateCategoryStep> = {}): CreateCategoryStep => ({

--- a/frontend/src/flow/registry/CreateChannel.test.ts
+++ b/frontend/src/flow/registry/CreateChannel.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { CreateChannelStep } from "../schema";
-
 import { CreateChannelEntry } from "./CreateChannel";
 
 const channel = (overrides: Partial<CreateChannelStep["channels"][number]> = {}) => ({

--- a/frontend/src/flow/registry/CreateRole.test.ts
+++ b/frontend/src/flow/registry/CreateRole.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { CreateRoleStep } from "../schema";
-
 import { CreateRoleEntry } from "./CreateRole";
 
 const makeStep = (overrides: Partial<CreateRoleStep> = {}): CreateRoleStep => ({

--- a/frontend/src/flow/registry/DeleteCategory.test.ts
+++ b/frontend/src/flow/registry/DeleteCategory.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { DeleteCategoryStep } from "../schema";
-
 import { DeleteCategoryEntry } from "./DeleteCategory";
 
 const step = (overrides: Partial<DeleteCategoryStep> = {}): DeleteCategoryStep => ({

--- a/frontend/src/flow/registry/DeleteChannel.test.ts
+++ b/frontend/src/flow/registry/DeleteChannel.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { DeleteChannelStep } from "../schema";
-
 import { DeleteChannelEntry } from "./DeleteChannel";
 
 const step = (overrides: Partial<DeleteChannelStep> = {}): DeleteChannelStep => ({

--- a/frontend/src/flow/registry/DeleteRole.test.ts
+++ b/frontend/src/flow/registry/DeleteRole.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { DeleteRoleStep } from "../schema";
-
 import { DeleteRoleEntry } from "./DeleteRole";
 
 const step = (overrides: Partial<DeleteRoleStep> = {}): DeleteRoleStep => ({

--- a/frontend/src/flow/registry/RandomSelect.test.ts
+++ b/frontend/src/flow/registry/RandomSelect.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { RandomSelectStep } from "../schema";
-
 import { RandomSelectEntry } from "./RandomSelect";
 
 const makeStep = (overrides: Partial<RandomSelectStep> = {}): RandomSelectStep => ({

--- a/frontend/src/flow/registry/SetGameFlag.test.ts
+++ b/frontend/src/flow/registry/SetGameFlag.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { SetGameFlagStep } from "../schema";
-
 import { SetGameFlagStepSchema } from "../schema";
 import { SetGameFlagEntry } from "./SetGameFlag";
 

--- a/frontend/src/flow/registry/ShuffleAssign.test.ts
+++ b/frontend/src/flow/registry/ShuffleAssign.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { ShuffleAssignStep } from "../schema";
-
 import { ShuffleAssignEntry } from "./ShuffleAssign";
 
 const makeStep = (overrides: Partial<ShuffleAssignStep> = {}): ShuffleAssignStep => ({

--- a/frontend/src/flow/registry/execute.test.ts
+++ b/frontend/src/flow/registry/execute.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, test } from "bun:test";
 
 import type { ConditionNode } from "@/components/Node/utils/evaluateCondition";
 
+import { createFakeContext } from "../engine/fakeContext";
 import type { ExecuteContext } from "../engine/types";
 import type { Step } from "../schema";
-
-import { createFakeContext } from "../engine/fakeContext";
 import { getEntry } from "./index";
 
 // 各ステップタイプの execute() を、インメモリ ExecuteContext (createFakeContext) で検証する。

--- a/frontend/src/flow/registry/index.ts
+++ b/frontend/src/flow/registry/index.ts
@@ -1,6 +1,4 @@
 import type { Step } from "../schema";
-import type { StepRegistryEntry } from "./types";
-
 import { AddRoleToRoleMembersEntry } from "./AddRoleToRoleMembers";
 import { BranchEntry } from "./Branch";
 import { ChangeChannelPermissionEntry } from "./ChangeChannelPermission";
@@ -18,6 +16,7 @@ import { RecordCombinationEntry } from "./RecordCombination";
 import { SendMessageEntry } from "./SendMessage";
 import { SetGameFlagEntry } from "./SetGameFlag";
 import { ShuffleAssignEntry } from "./ShuffleAssign";
+import type { StepRegistryEntry } from "./types";
 
 // 全ステップタイプの登録リスト。ステップタイプを増やす = ここに 1 行追加するだけ。
 // 表示順は「操作 → 分岐 → ツール」のおおまかな並び。

--- a/frontend/src/flow/resources.test.ts
+++ b/frontend/src/flow/resources.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import type { FlowData } from "./schema";
-
 import {
   collectFlagKeyOptions,
   collectFlagValueOptions,
   collectResourcesFromFlow,
   formatFlagValue,
 } from "./resources";
+import type { FlowData } from "./schema";
 
 const flow: FlowData = {
   version: 1,

--- a/frontend/src/flow/runner/RunnerDetailPanel.tsx
+++ b/frontend/src/flow/runner/RunnerDetailPanel.tsx
@@ -3,14 +3,13 @@ import { useMemo } from "react";
 
 import { TemplateResourcesOverrideProvider } from "@/components/Node/utils/useTemplateResources";
 
-import type { BranchStep, Step } from "../schema";
-import type { RunHandlers } from "./types";
-
 import { getEntry } from "../registry";
 import { collectResourcesFromFlow } from "../resources";
+import type { BranchStep, Step } from "../schema";
 import { useRunnerStore } from "../store/runnerStore";
 import { findStep } from "../treeOps";
 import { RunnerToolPanel } from "./RunnerToolPanel";
+import type { RunHandlers } from "./types";
 
 // 中央カラム (execute モード)。選択中ステップの実行操作 + 詳細を表示する。
 // - 実行済みステップは read-only (記録保護)。runnable なら [再実行] のみ許す。

--- a/frontend/src/flow/runner/RunnerStepList.tsx
+++ b/frontend/src/flow/runner/RunnerStepList.tsx
@@ -1,13 +1,12 @@
 import clsx from "clsx";
 import { memo } from "react";
 
-import type { BranchStep, Step } from "../schema";
-import type { RunHandlers } from "./types";
-
 import { getEntry } from "../registry";
 import { CATEGORY_CLASS, CATEGORY_LABEL } from "../registry/category";
+import type { BranchStep, Step } from "../schema";
 import { useRunnerStore } from "../store/runnerStore";
 import { canRunStep } from "./canRun";
+import type { RunHandlers } from "./types";
 
 interface RunnerStepRowProps {
   step: Step;

--- a/frontend/src/flow/runner/RunnerStepListPanel.tsx
+++ b/frontend/src/flow/runner/RunnerStepListPanel.tsx
@@ -1,7 +1,6 @@
-import type { RunHandlers } from "./types";
-
 import { useRunnerStore } from "../store/runnerStore";
 import { RunnerStepList } from "./RunnerStepList";
+import type { RunHandlers } from "./types";
 
 // 左カラム全体 (execute モード)。セクションを縦に並べ、各セクションのステップリストを描画する。
 // edit モードと違いセクションの追加・改名は無く、折りたたみのみ可能。

--- a/frontend/src/flow/runner/RunnerToolDock.tsx
+++ b/frontend/src/flow/runner/RunnerToolDock.tsx
@@ -1,8 +1,7 @@
 import { useMemo } from "react";
 
-import type { Step } from "../schema";
-
 import { getEntry } from "../registry";
+import type { Step } from "../schema";
 import { useRunnerStore } from "../store/runnerStore";
 import { collectSteps } from "../treeOps";
 import { counterNextValue } from "./toolOperate";

--- a/frontend/src/flow/runner/RunnerToolPanel.tsx
+++ b/frontend/src/flow/runner/RunnerToolPanel.tsx
@@ -3,9 +3,8 @@ import { useMemo, useState } from "react";
 import { PortaledSelect } from "@/components/Node/utils/PortaledSelect";
 import { getFilteredTargetOptions } from "@/components/Node/utils/recordCombination";
 
-import type { KanbanStep, RecordCombinationStep, Step } from "../schema";
-
 import { generateId } from "../ids";
+import type { KanbanStep, RecordCombinationStep, Step } from "../schema";
 import { useRunnerStore } from "../store/runnerStore";
 import {
   counterNextValue,

--- a/frontend/src/flow/runner/RunnerView.tsx
+++ b/frontend/src/flow/runner/RunnerView.tsx
@@ -2,8 +2,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { DiscordBotData, GameSession } from "@/db";
 
-import type { RunHandlers } from "./types";
-
 import { MessageAttachmentTargetProvider } from "../components/messageContext";
 import { FlowDataSchema } from "../schema";
 import { useRunnerStore } from "../store/runnerStore";
@@ -11,6 +9,7 @@ import { RunnerDetailPanel } from "./RunnerDetailPanel";
 import { RunnerFlagPanel } from "./RunnerFlagPanel";
 import { RunnerStepListPanel } from "./RunnerStepListPanel";
 import { RunnerToolDock } from "./RunnerToolDock";
+import type { RunHandlers } from "./types";
 import { useSessionRunner } from "./useSessionRunner";
 
 const AUTOSAVE_DEBOUNCE_MS = 500;

--- a/frontend/src/flow/runner/canRun.test.ts
+++ b/frontend/src/flow/runner/canRun.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { Step } from "../schema";
-
 import { canRunStep } from "./canRun";
 
 const step = (overrides: Partial<Step>): Step =>

--- a/frontend/src/flow/runner/canRun.ts
+++ b/frontend/src/flow/runner/canRun.ts
@@ -1,6 +1,5 @@
-import type { Step } from "../schema";
-
 import { getEntry } from "../registry";
+import type { Step } from "../schema";
 
 // GM 入力なしに実行できるステップか。execute() を持ち、かつ select 分岐でないこと
 // (select は枝選択が必要)。tool は execute() を持たないため false。

--- a/frontend/src/flow/runner/toolOperate.test.ts
+++ b/frontend/src/flow/runner/toolOperate.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { KanbanStep, RecordCombinationStep } from "../schema";
-
 import {
   counterNextValue,
   drawRandomSelect,

--- a/frontend/src/flow/runner/useSessionRunner.ts
+++ b/frontend/src/flow/runner/useSessionRunner.ts
@@ -1,15 +1,13 @@
 import { useCallback } from "react";
 
 import type { DiscordBotData, GameSession } from "@/db";
-
 import { useToast } from "@/toast/ToastProvider";
 
 import type { StepRunner } from "../engine/execute";
-import type { ExecuteContext } from "../engine/types";
-
 import { runChain } from "../engine/execute";
 import { createDiscordGateway } from "../engine/gateway";
 import { loadResourceStore } from "../engine/resourceStore";
+import type { ExecuteContext } from "../engine/types";
 import { getEntry } from "../registry";
 import { useRunnerStore } from "../store/runnerStore";
 import { findStep } from "../treeOps";

--- a/frontend/src/flow/schema.ts
+++ b/frontend/src/flow/schema.ts
@@ -1,8 +1,7 @@
 import z from "zod";
 
-import type { ConditionNode } from "@/components/Node/utils/evaluateCondition";
-
 import { DynamicValueSchema } from "@/components/Node/utils/DynamicValue";
+import type { ConditionNode } from "@/components/Node/utils/evaluateCondition";
 import { MessageBlockSchema } from "@/components/Node/utils/messageSchema";
 
 // ステップツリー型データモデル (issue #182 / #183)。

--- a/frontend/src/flow/store/editorStore.ts
+++ b/frontend/src/flow/store/editorStore.ts
@@ -1,10 +1,9 @@
 import { create } from "zustand";
 
-import type { Section, StepLocation } from "../treeOps";
-
 import { generateId } from "../ids";
 import { getEntry } from "../registry";
 import { defaultFlowData, type FlowData, type Step } from "../schema";
+import type { Section, StepLocation } from "../treeOps";
 import * as treeOps from "../treeOps";
 
 // edit モード (テンプレート作成) の Zustand store。

--- a/frontend/src/flow/store/runnerStore.test.ts
+++ b/frontend/src/flow/store/runnerStore.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { FlowData, Step } from "../schema";
-
 import { findStep } from "../treeOps";
 import { useRunnerStore } from "./runnerStore";
 

--- a/frontend/src/flow/treeOps.test.ts
+++ b/frontend/src/flow/treeOps.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import type { FlowData, Step } from "./schema";
-
 import {
   clearDescendantExecution,
   collectDescendantStepIds,

--- a/frontend/src/flow/treeOps.ts
+++ b/frontend/src/flow/treeOps.ts
@@ -1,8 +1,7 @@
 import { produce } from "immer";
 
-import type { FlowData, Step } from "./schema";
-
 import { generateId } from "./ids";
+import type { FlowData, Step } from "./schema";
 
 // FlowData のツリー (Section[] > Step[]、Branch は branches[].steps に再帰) を
 // 純粋に変換するヘルパ群。**ツリーが再帰的であることを知るのはこのファイルだけ**で、

--- a/frontend/src/flow/wizard/TemplateWizard.tsx
+++ b/frontend/src/flow/wizard/TemplateWizard.tsx
@@ -1,9 +1,8 @@
 import { useMemo, useState } from "react";
 
-import type { FlowData } from "../schema";
-
 import { getEntry } from "../registry";
 import { CATEGORY_CLASS, CATEGORY_LABEL } from "../registry/category";
+import type { FlowData } from "../schema";
 import {
   defaultWizardParams,
   generateWizardFlow,

--- a/frontend/src/flow/wizard/generateFlow.ts
+++ b/frontend/src/flow/wizard/generateFlow.ts
@@ -1,3 +1,4 @@
+import { generateId } from "../ids";
 import type {
   AddRoleToRoleMembersStep,
   CreateCategoryStep,
@@ -9,8 +10,6 @@ import type {
   Step,
 } from "../schema";
 import type { Section } from "../treeOps";
-
-import { generateId } from "../ids";
 
 // 新規テンプレートウィザード (旧 Blueprint ノードの置き換え)。
 // キャラクター名 / VC 数 / カテゴリ名 / 共通テキストチャンネルから、

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
 
 import { routeTree } from "./routeTree.gen";
+
 import "./styles.css";
 
 async function enableMockingIfNeeded(): Promise<void> {

--- a/frontend/src/routes/template/wizard.tsx
+++ b/frontend/src/routes/template/wizard.tsx
@@ -1,9 +1,8 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 
-import type { FlowData } from "@/flow/schema";
-
 import { Template } from "@/db";
+import type { FlowData } from "@/flow/schema";
 import { TemplateWizard } from "@/flow/wizard/TemplateWizard";
 import { useToast } from "@/toast/ToastProvider";
 

--- a/frontend/src/stores/nodeFilePaths.test.ts
+++ b/frontend/src/stores/nodeFilePaths.test.ts
@@ -1,8 +1,7 @@
 import { describe, test, expect } from "bun:test";
 
-import type { FlowNode } from "./templateEditorStore";
-
 import { collectFilePathsFromNode, collectFilePathsFromNodes } from "./nodeFilePaths";
+import type { FlowNode } from "./templateEditorStore";
 
 const makeSendMessageNode = (filePaths: string[]): FlowNode =>
   ({

--- a/frontend/src/stores/templateEditorStore.ts
+++ b/frontend/src/stores/templateEditorStore.ts
@@ -7,9 +7,8 @@ import type {
   Viewport,
   NodeRemoveChange,
 } from "@xyflow/react";
-import type { z } from "zod";
-
 import { applyNodeChanges, applyEdgeChanges, addEdge } from "@xyflow/react";
+import type { z } from "zod";
 import { create } from "zustand";
 
 import {

--- a/frontend/src/theme/ThemeIcon.tsx
+++ b/frontend/src/theme/ThemeIcon.tsx
@@ -1,5 +1,4 @@
 import type { THEME } from ".";
-
 import { useTheme } from "./ThemeProvider";
 
 interface Props {

--- a/frontend/test/factories.ts
+++ b/frontend/test/factories.ts
@@ -1,9 +1,8 @@
+import { db } from "@/db";
 import type { GameSession } from "@/db/models/GameSession";
 import type { ReactFlowData } from "@/db/schemas";
-import type { FlowData } from "@/flow/schema";
-
-import { db } from "@/db";
 import { defaultReactFlowData } from "@/db/schemas";
+import type { FlowData } from "@/flow/schema";
 import { defaultFlowData } from "@/flow/schema";
 
 interface SessionFactoryOptions {

--- a/frontend/test/stories/Flow/DetailPanel.stories.tsx
+++ b/frontend/test/stories/Flow/DetailPanel.stories.tsx
@@ -1,9 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import type { Step } from "@/flow/schema";
-
 import { DetailPanel } from "@/flow/components/DetailPanel";
 import { getEntry } from "@/flow/registry";
+import type { Step } from "@/flow/schema";
 import { useEditorStore } from "@/flow/store/editorStore";
 
 // registry の defaults をベースに、表示が意味を持つよう具体値を被せた 1 ステップを

--- a/frontend/test/stories/Node/nodes/_render.tsx
+++ b/frontend/test/stories/Node/nodes/_render.tsx
@@ -1,6 +1,6 @@
+import { ReactFlow, ReactFlowProvider, type Node, type NodeTypes } from "@xyflow/react";
 import type { ComponentType, CSSProperties } from "react";
 
-import { ReactFlow, ReactFlowProvider, type Node, type NodeTypes } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 
 interface RenderSingleNodeOptions<TData extends Record<string, unknown>> {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "@types/node": "26.2.0",
     "knip": "6.11.0",
     "npm-check-updates": "23.0.2",
-    "oxfmt": "0.17.0",
-    "oxlint": "1.32.0",
+    "oxfmt": "0.62.0",
+    "oxlint": "1.77.0",
     "oxlint-tsgolint": "0.23.0",
     "typescript": "6.0.3",
     "wrangler": "4.120.0"


### PR DESCRIPTION
## Summary

| package | before | after |
|---|---|---|
| `oxlint` | 1.32.0 | 1.77.0 |
| `oxfmt` | 0.17.0 | 0.62.0 |

Both packages ship from the same `oxc-project/oxc` repo release train and are usually bumped in lockstep.

### Research

Skimmed the upstream `npm/oxlint/CHANGELOG.md` and `npm/oxfmt/CHANGELOG.md` for the full version range:

- **oxlint**: no removed/renamed *default* rules found. The only `BREAKING` entry in range was dropping the unused `oxc_language_server` binary — not used by this repo. Several new opt-in rules were added, but oxlint's defaults didn't newly flag anything: `bun run --bun lint` (oxlint step) came back clean before any fixes were needed.
- **oxfmt**: two `BREAKING` entries in range, both scoped to `experimentalSortImports.customGroups` config we don't use (a group-name rename and a prefix→glob pattern change). More relevant: oxfmt (and oxlint's linter core) changed how `ignorePatterns` are resolved — now strictly rooted at the config file's directory (added ~0.59.0 / 1.74.0) instead of the previous, looser resolution. That surfaced a real bug in this repo's `.oxfmtrc.jsonc` (see below). Also unrelated formatting-behavior additions in range: JSDoc comment formatting, `package.json` sorting on by default, `.editorconfig` support — expected to reformat files, not break anything.

### Fixes required

1. **`.oxfmtrc.jsonc` `ignorePatterns` bug**: the entry `"src/routeTree.gen.ts"` was meant to exclude the TanStack Router–generated file at `frontend/src/routeTree.gen.ts`, but the config lives at the repo root. With the new strict, config-dir-rooted resolution, that pattern no longer matched, and the generated file started getting reformatted on every `format`/`lint` run. Fixed by rewriting the pattern as `frontend/src/routeTree.gen.ts` (repo-root-relative), which restores the original exclusion. Left a comment explaining why the path is root-relative.
2. **Formatting diff**: ran `bun run --bun format` across the workspace to apply oxfmt's updated formatting rules (mostly import-grouping/blank-line changes between `import type` and value imports). Verified a second `format` run is a no-op (idempotent).

No oxlint rule needed to be disabled — the defaults stayed clean against this codebase.

## Test plan

- [x] `bun install`
- [x] `bun run --bun lint` — clean (oxlint + `oxfmt --check`)
- [x] `bun run --bun format` — applied once, confirmed idempotent on a second run
- [x] `bun run --bun test` — 48 backend + 588 frontend tests pass, 0 fail
- [x] `bun run --bun typecheck` — passes (both packages)
- [x] `bun run knip` — passes (pre-existing unrelated config hint only)
- [x] `bun run --bun build` — frontend build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRGFemRkXTTUjbh4ysTR7G

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRGFemRkXTTUjbh4ysTR7G)_